### PR TITLE
Phase 4: structural drill-down for case law judgments (LegalDocML eId)

### DIFF
--- a/src/gateway.py
+++ b/src/gateway.py
@@ -110,8 +110,9 @@ gateway = FastMCP(
     lifespan=http_lifespan,
     instructions=(
         "UK legal research server. Eight namespaced modules:\n\n"
-        "• case_law_search / case_law_get_judgment\n"
-        "  Search and retrieve UK court judgments from TNA Find Case Law.\n\n"
+        "• case_law_search / case_law_grep_judgment\n"
+        "  Search UK court judgments from TNA Find Case Law and grep within them.\n"
+        "  Read judgment content via judgment://{slug}/{header,index,para/{eId}} resources.\n\n"
         "• legislation_search / legislation_get_toc / legislation_get_section\n"
         "  Find Acts of Parliament and Statutory Instruments. Always check 'extent' field.\n\n"
         "• parliament_search_hansard / parliament_vibe_check / parliament_find_member / parliament_member_interests / parliament_search_petitions\n"
@@ -180,6 +181,17 @@ gateway.mount(hmrc_mcp,        namespace="hmrc")
 
 register_case_law_resources(gateway)
 register_legislation_resources(gateway)
+
+
+# ---------------------------------------------------------------------------
+# Tool-only client coverage (Apps, ChatGPT, anything that can't speak
+# resources/read). The transform auto-generates list_resources +
+# read_resource tools at the gateway level. All middleware applies.
+# ---------------------------------------------------------------------------
+
+from fastmcp.server.transforms import ResourcesAsTools  # noqa: E402
+
+gateway.add_transform(ResourcesAsTools(gateway))
 
 
 # ---------------------------------------------------------------------------

--- a/src/modules/case_law/models.py
+++ b/src/modules/case_law/models.py
@@ -41,3 +41,43 @@ class JudgmentSearchResult(BaseModel):
     page: int = Field(..., description="Current page number (1-indexed)")
     has_more: bool = Field(..., description="Whether additional pages exist")
     total_pages: int | None = Field(None, description="Total page count if available from API")
+
+
+class CaseLawGrepInput(BaseModel):
+    """Input schema for case_law_grep_judgment."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    slug: str = Field(
+        ...,
+        min_length=8,
+        description="TNA judgment slug, e.g. 'uksc/2024/12' or 'ewca/civ/2023/450'.",
+    )
+    pattern: str = Field(
+        ...,
+        min_length=2,
+        max_length=200,
+        description=(
+            "Regex pattern (or plain substring) to search within paragraph text. "
+            "If the pattern doesn't compile as regex, falls back to literal substring match."
+        ),
+    )
+    case_insensitive: bool = Field(True, description="Default true. Set false for case-sensitive matching.")
+    max_hits: int = Field(25, ge=1, le=100, description="Cap on number of hits returned.")
+
+
+class GrepHit(BaseModel):
+    """A single paragraph match from grep_judgment."""
+
+    eId: str = Field(..., description="LegalDocML paragraph identifier, e.g. 'para_12'")
+    snippet: str = Field(..., description="~200 chars of context around the match")
+    match: str = Field(..., description="The exact text that matched the pattern")
+
+
+class GrepResult(BaseModel):
+    """Output schema for case_law_grep_judgment."""
+
+    slug: str = Field(..., description="The judgment slug that was searched")
+    pattern: str = Field(..., description="The pattern that was searched for")
+    hits: list[GrepHit] = Field(..., description="Matching paragraphs in document order")
+    truncated: bool = Field(..., description="True if hit count reached max_hits and more matches may exist")

--- a/src/modules/case_law/parsers.py
+++ b/src/modules/case_law/parsers.py
@@ -1,0 +1,101 @@
+"""Pure-function LegalDocML parsing helpers.
+
+No HTTP, no FastMCP, no Pydantic — testable offline against the committed
+fixture (`tests/live/fixtures/uksc_2024_12_full.xml`).
+
+Sub-paragraphs without `eId` are nested inside their parent `<paragraph eId>`
+and ride along inside the parent's serialised XML automatically.
+"""
+
+import re
+
+from lxml import etree
+
+LEGALDOCML_NS = {
+    "akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0",
+    "uk": "https://caselaw.nationalarchives.gov.uk/akn",
+}
+
+_FIRST_LINE_MAX = 120
+_SNIPPET_RADIUS = 100
+
+
+def _root(xml_text: str) -> etree._Element:
+    return etree.fromstring(xml_text.encode())
+
+
+def _first_line(el: etree._Element, max_len: int = _FIRST_LINE_MAX) -> str:
+    return " ".join(el.itertext()).strip().replace("\n", " ")[:max_len]
+
+
+def extract_index(xml_text: str) -> str:
+    """Return one 'eId: first_line' row per `<paragraph eId>` in document order."""
+    root = _root(xml_text)
+    rows = []
+    for p in root.findall(".//akn:paragraph", LEGALDOCML_NS):
+        eId = p.get("eId")
+        if eId:
+            rows.append(f"{eId}: {_first_line(p)}")
+    return "\n".join(rows)
+
+
+def extract_header(xml_text: str) -> str:
+    """Return `<header>...</header>` serialised back to XML."""
+    root = _root(xml_text)
+    header = root.find(".//akn:header", LEGALDOCML_NS)
+    if header is None:
+        raise KeyError("No <header> element in this judgment")
+    return etree.tostring(header, pretty_print=False).decode()
+
+
+def extract_paragraph(xml_text: str, eId: str) -> str:
+    """Return a single `<paragraph eId="X">` serialised back to XML."""
+    root = _root(xml_text)
+    el = root.find(f".//akn:paragraph[@eId='{eId}']", LEGALDOCML_NS)
+    if el is None:
+        raise KeyError(f"No paragraph with eId={eId!r}")
+    return etree.tostring(el, pretty_print=False).decode()
+
+
+def grep_paragraphs(
+    xml_text: str,
+    pattern: str,
+    *,
+    case_insensitive: bool = True,
+    max_hits: int = 25,
+) -> list[dict]:
+    """Find paragraphs whose text content matches `pattern`.
+
+    Returns up to `max_hits` items, each `{eId, snippet, match}`. Snippet
+    is ~200 chars centred on the first match in that paragraph.
+
+    Pattern is regex; if it doesn't compile, falls back to literal
+    substring search.
+    """
+    flags = re.IGNORECASE if case_insensitive else 0
+    try:
+        rx = re.compile(pattern, flags)
+    except re.error:
+        rx = re.compile(re.escape(pattern), flags)
+
+    root = _root(xml_text)
+    hits: list[dict] = []
+    for p in root.findall(".//akn:paragraph", LEGALDOCML_NS):
+        eId = p.get("eId")
+        if not eId:
+            continue
+        text = " ".join(p.itertext())
+        m = rx.search(text)
+        if not m:
+            continue
+        start = max(0, m.start() - _SNIPPET_RADIUS)
+        end = min(len(text), m.end() + _SNIPPET_RADIUS)
+        snippet = text[start:end].strip()
+        if start > 0:
+            snippet = "…" + snippet
+        if end < len(text):
+            snippet = snippet + "…"
+        hits.append({"eId": eId, "snippet": snippet, "match": m.group(0)})
+        if len(hits) >= max_hits:
+            break
+    return hits

--- a/src/modules/case_law/resources.py
+++ b/src/modules/case_law/resources.py
@@ -1,36 +1,83 @@
 """Resource templates for case law (TNA Find Case Law).
 
-Registered on the GATEWAY, not on the sub-MCP, because mounted sub-MCPs
-silently break RFC 6570 wildcard substitution. See issue #3.
+Three sub-path templates that drill down into a LegalDocML judgment by
+its native paragraph identifiers (`eId`). Avoids the 56k-token blowout
+the bare `judgment://{slug*}` (Phase 3) caused.
 
-URI scheme is `judgment` (not `case_law`) because RFC 3986 forbids
-underscores in scheme names — but allows them in the authority position.
+Registered on the GATEWAY, not on the sub-MCP, because mounted sub-MCPs
+silently break RFC 6570 wildcard substitution (issue #3).
+
+URI scheme is `judgment` (not `case_law`) — RFC 3986 forbids underscores
+in scheme names.
 """
 
 import httpx
 from fastmcp import Context, FastMCP
 
+from . import parsers
+
 TNA_BASE = "https://caselaw.nationalarchives.gov.uk"
+
+
+async def _fetch_xml(slug: str, ctx: Context) -> str:
+    """Fetch the full LegalDocML XML for a judgment slug. Cached upstream
+    by the case_law sub-module's ResponseCachingMiddleware (1h TTL)."""
+    client: httpx.AsyncClient = ctx.lifespan_context["xml_http"]
+    url = f"{TNA_BASE}/{slug.lstrip('/')}/data.xml"
+    resp = await client.get(url)
+    resp.raise_for_status()
+    return resp.text
 
 
 def register_case_law_resources(gateway: FastMCP) -> None:
     """Register case-law resource templates on the gateway."""
 
     @gateway.resource(
-        "judgment://{slug*}",
-        name="UK Court Judgment (LegalDocML XML)",
+        "judgment://{slug*}/header",
+        name="UK Court Judgment — metadata header",
         description=(
-            "Full LegalDocML XML for a TNA Find Case Law judgment. "
-            "Slug formats: 'uksc/2024/12', 'ewca/civ/2023/450', or a UUID for "
-            "post-April 2025 docs. Use `case_law_search` first to discover slugs."
+            "Metadata for a TNA judgment: parties, judges, neutral citation, "
+            "court, dates. ~1,000 tokens. Call this first to understand what "
+            "a judgment is. Slug examples: 'uksc/2024/12', 'ewca/civ/2023/450'."
         ),
         mime_type="application/xml",
         annotations={"readOnlyHint": True, "idempotentHint": True},
         tags={"case_law", "tna", "judgment"},
     )
-    async def judgment_xml(slug: str, ctx: Context) -> str:
-        client: httpx.AsyncClient = ctx.lifespan_context["xml_http"]
-        url = f"{TNA_BASE}/{slug.lstrip('/')}/data.xml"
-        resp = await client.get(url)
-        resp.raise_for_status()
-        return resp.text
+    async def judgment_header(slug: str, ctx: Context) -> str:
+        xml = await _fetch_xml(slug, ctx)
+        return parsers.extract_header(xml)
+
+    @gateway.resource(
+        "judgment://{slug*}/index",
+        name="UK Court Judgment — paragraph index",
+        description=(
+            "Navigation index: 'eId: first_line' rows for every paragraph "
+            "in the judgment (~4,000 tokens for a typical Supreme Court case). "
+            "Read this to discover paragraph identifiers, then drill into "
+            "specific paragraphs via judgment://{slug}/para/{eId}. To find "
+            "paragraphs by content, use the case_law_grep_judgment tool."
+        ),
+        mime_type="text/plain",
+        annotations={"readOnlyHint": True, "idempotentHint": True},
+        tags={"case_law", "tna", "judgment", "navigation"},
+    )
+    async def judgment_index(slug: str, ctx: Context) -> str:
+        xml = await _fetch_xml(slug, ctx)
+        return parsers.extract_index(xml)
+
+    @gateway.resource(
+        "judgment://{slug*}/para/{eId}",
+        name="UK Court Judgment — single paragraph",
+        description=(
+            "A single <paragraph> element by its LegalDocML eId (e.g. 'para_12'). "
+            "Returns the paragraph and any nested sub-paragraphs. Typical size "
+            "400-1,700 tokens. Use the index resource to discover available eIds."
+        ),
+        mime_type="application/xml",
+        annotations={"readOnlyHint": True, "idempotentHint": True},
+        tags={"case_law", "tna", "judgment", "paragraph"},
+    )
+    async def judgment_paragraph(slug: str, eId: str, ctx: Context) -> str:
+        xml = await _fetch_xml(slug, ctx)
+        return parsers.extract_paragraph(xml, eId)

--- a/src/modules/case_law/tools.py
+++ b/src/modules/case_law/tools.py
@@ -7,15 +7,21 @@ Rate limit: 1,000 requests / 5 min per IP.
 """
 
 import hashlib
-import json
 from datetime import date, datetime
 
 import httpx
 from fastmcp import FastMCP, Context
 from pydantic import BaseModel, ConfigDict, Field
 
-from ...deps import format_http_error
-from .models import JudgmentIdentifier, JudgmentSearchResult, JudgmentSummary
+from . import parsers
+from .models import (
+    CaseLawGrepInput,
+    GrepHit,
+    GrepResult,
+    JudgmentIdentifier,
+    JudgmentSearchResult,
+    JudgmentSummary,
+)
 
 TNA_BASE = "https://caselaw.nationalarchives.gov.uk"
 
@@ -37,32 +43,6 @@ class CaseLawSearchInput(BaseModel):
     from_date: date | None = Field(None, description="Earliest judgment date (YYYY-MM-DD)")
     to_date: date | None = Field(None, description="Latest judgment date (YYYY-MM-DD)")
     page: int = Field(1, description="Result page number (1-indexed)", ge=1, le=50)
-
-
-class CaseLawGetJudgmentInput(BaseModel):
-    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
-
-    uri: str = Field(
-        ...,
-        description=(
-            "TNA judgment URI slug, e.g. 'uksc/2024/12' or 'ewca/civ/2023/450'. "
-            "Always use the 'uri' field returned by case_law_search — do not construct manually."
-        ),
-        min_length=8,
-    )
-    max_chars: int = Field(
-        50000,
-        description=(
-            "Maximum number of characters of LegalDocML XML to return. "
-            "Default 50,000 (~12,500 tokens) keeps a single judgment under "
-            "10% of a 200k-token context window. Set higher (e.g. 200000) "
-            "to fetch a complete judgment when you need every clause; the "
-            "tool will return up to that many chars and flag if truncation "
-            "occurred."
-        ),
-        ge=1000,
-        le=400000,
-    )
 
 
 def _parse_atom_feed(xml_bytes: bytes) -> JudgmentSearchResult:
@@ -164,7 +144,10 @@ def register_tools(mcp: FastMCP) -> None:
         """Search UK case law via the TNA Find Case Law API.
 
         Returns paginated judgment summaries: neutral citations, court, dates, stable URIs.
-        Use case_law_get_judgment with the returned uri to fetch full text.
+        Use the judgment://{slug}/header resource to inspect a result, then
+        judgment://{slug}/index to discover paragraphs and judgment://{slug}/para/{eId}
+        to read individual paragraphs. For content-based discovery within a
+        judgment, use case_law_grep_judgment.
 
         Args:
             params: CaseLawSearchInput with query, optional filters (court, judge,
@@ -182,48 +165,44 @@ def register_tools(mcp: FastMCP) -> None:
         return _parse_atom_feed(resp.content)
 
     @mcp.tool(
-        name="get_judgment",
-        annotations={"title": "Get Full Judgment Text", "readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": True},
+        name="grep_judgment",
+        annotations={
+            "title": "Search within a UK Court Judgment",
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        },
     )
-    async def case_law_get_judgment(params: CaseLawGetJudgmentInput, ctx: Context) -> dict:
-        """Retrieve the full LegalDocML XML for a judgment by TNA URI slug.
+    async def case_law_grep_judgment(params: CaseLawGrepInput, ctx: Context) -> GrepResult:
+        """Find paragraphs in a single judgment whose text matches a pattern.
 
-        DEPRECATED: prefer the resource template `judgment://{slug}` for
-        clients that support `resources/read`. This tool will be removed in
-        v0.4. The resource returns the same XML without the `max_chars`
-        truncation parameter (Phase 4 will introduce structural drill-down).
+        Returns a list of `{eId, snippet, match}` hits — small per-paragraph
+        snippets centred on the match — so the LLM can decide which full
+        paragraphs to read via judgment://{slug}/para/{eId}.
 
-        Returns a dict with the LegalDocML XML, truncated to `max_chars`
-        if necessary. Caller controls payload size via the max_chars
-        parameter — defaults to 50,000 chars to stay well under typical
-        LLM context budgets.
+        Use this when answering content-based questions ("what did the judges
+        say about negligence?", "find the test for foreseeability", "did this
+        case cite Donoghue?") rather than navigating by paragraph number
+        (which uses the index resource).
 
-        Args:
-            params (CaseLawGetJudgmentInput): uri (TNA slug), max_chars (cap).
-
-        Returns:
-            dict: Keys 'uri', 'format', 'content' (LegalDocML XML),
-                'truncated' (bool), 'original_length' (int).
-                On failure: 'error' key.
+        Pattern is regex; if it doesn't compile, falls back to literal
+        substring search.
         """
-        try:
-            client: httpx.AsyncClient = ctx.lifespan_context["xml_http"]
-            uri = params.uri.lstrip("/")
-            resp = await client.get(f"{TNA_BASE}/{uri}/data.xml")
-            resp.raise_for_status()
+        client: httpx.AsyncClient = ctx.lifespan_context["xml_http"]
+        slug = params.slug.lstrip("/")
+        resp = await client.get(f"{TNA_BASE}/{slug}/data.xml")
+        resp.raise_for_status()
 
-            xml_text = resp.text
-            original_length = len(xml_text)
-            truncated = original_length > params.max_chars
-            if truncated:
-                xml_text = xml_text[: params.max_chars] + "\n<!-- ...truncated -->"
-
-            return {
-                "uri": uri,
-                "format": "legaldocml-xml",
-                "content": xml_text,
-                "truncated": truncated,
-                "original_length": original_length,
-            }
-        except Exception as e:
-            return {"error": format_http_error(e)}
+        hits = parsers.grep_paragraphs(
+            resp.text,
+            params.pattern,
+            case_insensitive=params.case_insensitive,
+            max_hits=params.max_hits,
+        )
+        return GrepResult(
+            slug=slug,
+            pattern=params.pattern,
+            hits=[GrepHit(**h) for h in hits],
+            truncated=len(hits) >= params.max_hits,
+        )

--- a/tests/live/fixtures/uksc_2024_12_full.xml
+++ b/tests/live/fixtures/uksc_2024_12_full.xml
@@ -1,0 +1,1325 @@
+<akomaNtoso xmlns="http://docs.oasis-open.org/legaldocml/ns/akn/3.0" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:uk="https://caselaw.nationalarchives.gov.uk/akn">
+  <judgment name="judgment">
+    <meta>
+      <identification source="#tna">
+	<FRBRWork>
+	  <FRBRthis value="https://caselaw.nationalarchives.gov.uk/id/uksc/2024/12"/>
+	  <FRBRuri value="https://caselaw.nationalarchives.gov.uk/id/uksc/2024/12"/>
+	  <FRBRdate date="2024-04-17" name="judgment"/>
+	  <FRBRauthor href="#uksc"/>
+	  <FRBRcountry value="GB-UKM"/>
+	  <FRBRnumber value="12"/>
+	  <FRBRname value="Secretary of State for Business and Trade v Mercer"/>
+	</FRBRWork>
+	<FRBRExpression>
+	  <FRBRthis value="https://caselaw.nationalarchives.gov.uk/uksc/2024/12"/>
+	  <FRBRuri value="https://caselaw.nationalarchives.gov.uk/uksc/2024/12"/>
+	  <FRBRdate date="2024-04-17" name="judgment"/>
+	  <FRBRauthor href="#uksc"/>
+	  <FRBRlanguage language="eng"/>
+	</FRBRExpression>
+	<FRBRManifestation>
+	  <FRBRthis value="https://caselaw.nationalarchives.gov.uk/uksc/2024/12/data.xml"/>
+	  <FRBRuri value="https://caselaw.nationalarchives.gov.uk/uksc/2024/12/data.xml"/>
+	  <FRBRdate date="2024-11-22T05:01:07" name="transform"/>
+	  <FRBRdate date="2024-11-27T05:06:52" name="tna-enriched"/>
+	  <FRBRauthor href="#tna"/>
+	  <FRBRformat value="application/xml"/>
+	</FRBRManifestation>
+      </identification>
+      <lifecycle source="#">
+	<eventRef date="2024-04-17" refersTo="#judgment" source="#"/>
+      </lifecycle>
+      <references source="#tna">
+	<TLCOrganization eId="uksc" href="https://www.supremecourt.uk/" showAs="The Supreme Court"/>
+	<TLCOrganization eId="tna" href="https://www.nationalarchives.gov.uk/" showAs="The National Archives"/>
+	<TLCEvent eId="judgment" href="#" showAs="judgment"/>
+	<TLCPerson eId="secretary-of-state-for-business-and-trade" href="" showAs="Secretary of State for Business and Trade"/>
+	<TLCPerson eId="mercer" href="" showAs="Mercer"/>
+	<TLCRole eId="respondent" href="" showAs="Respondent"/>
+	<TLCRole eId="appellant" href="" showAs="Appellant"/>
+	<TLCPerson eId="judge-lord-lloyd-jones" href="/judge-lord-lloyd-jones" showAs="Lord Lloyd-Jones"/>
+	<TLCPerson eId="judge-lord-hamblen" href="/judge-lord-hamblen" showAs="Lord Hamblen"/>
+	<TLCPerson eId="judge-lord-burrows" href="/judge-lord-burrows" showAs="Lord Burrows"/>
+	<TLCPerson eId="judge-lord-richards" href="/judge-lord-richards" showAs="Lord Richards"/>
+	<TLCPerson eId="judge-lady-simler" href="/judge-lady-simler" showAs="Lady Simler"/>
+      </references>
+      <proprietary source="#">
+	<uk:court>UKSC</uk:court>
+	<uk:year>2024</uk:year>
+	<uk:number>12</uk:number>
+	<uk:cite>[2024] UKSC 12</uk:cite>
+	<uk:parser>0.26.14</uk:parser>
+	<uk:hash>1eca1d72deecdb23c60de33d82c5da639ed2affc7a22979715698f37e60f5411</uk:hash>
+	<uk:tna-enrichment-engine>6.0.2</uk:tna-enrichment-engine>
+      </proprietary>
+      <presentation source="#">
+	<html:style>
+#judgment { font-size: 12pt; font-family: 'Calibri, sans-serif'; }
+#judgment .Normal { font-family: 'Calibri, sans-serif'; font-size: 12pt; }
+#judgment .Footer { font-family: Univers; font-size: 12pt; }
+#judgment .Caveat { text-align: justify; font-weight: bold; font-family: 'Calibri, sans-serif'; font-size: 10pt; }
+#judgment .Header { font-family: 'Calibri, sans-serif'; font-size: 12pt; }
+#judgment .ParaHeading1 { font-weight: bold; text-transform: uppercase; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .ParaNoNumber { font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .ParaLevel1 { margin-left: 0in; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .ParaLevel2 { margin-left: 0.5in; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .Quote { margin-left: 1in; margin-right: 0.87in; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .NewSpeech { font-weight: bold; text-transform: uppercase; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .Paraheading2 { font-weight: bold; font-family: 'Calibri, sans-serif'; font-size: 12pt; }
+#judgment .Paraheading3 { font-weight: bold; text-decoration-line: underline; text-decoration-style: solid; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .Embargo { text-align: justify; font-weight: bold; font-size: 10pt; }
+#judgment .JudgmentReferences { text-align: right; font-size: 12pt; }
+#judgment .Bulletpara { margin-left: 0.5in; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .Paraheading4 { font-style: italic; font-weight: bold; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .Paraheading5 { font-style: italic; text-decoration-line: underline; text-decoration-style: solid; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .Paraheading6 { font-style: italic; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .CourtOrder { font-weight: bold; font-size: 13pt; color: #C00000; }
+#judgment .JudgmentTitle { text-align: center; font-weight: bold; font-size: 20pt; }
+#judgment .JudgmentDetail1 { text-align: center; font-weight: bold; font-size: 20pt; }
+#judgment .ParaSubHeading1 { font-style: italic; font-weight: bold; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .ParaSubHeading2 { font-style: italic; text-decoration-line: underline; text-decoration-style: solid; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .ParaSubHeading3 { font-style: italic; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .ParaApprovedLevel1 { margin-left: 0in; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .ParaApprovedLevel2 { margin-left: 0.5in; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .ParaNoNumberApproved { font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .JudgmentJudges { text-align: center; font-weight: bold; font-size: 17pt; }
+#judgment .JudgmentAppRespInt { text-align: center; font-size: 12pt; }
+#judgment .ListParagraph { margin-left: 0.5in; font-size: 11pt; }
+#judgment .ParaLevel3 { margin-left: 0.98in; font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .CommentText { font-size: 10pt; }
+#judgment .Revision { font-family: 'Calibri, sans-serif'; font-size: 12pt; }
+#judgment .CommentSubject { font-weight: bold; font-family: 'Calibri, sans-serif'; font-size: 10pt; }
+#judgment .FooterChar { font-family: Univers; font-size: 12pt; }
+#judgment .HeaderChar { font-family: 'Times New Roman'; font-size: 12pt; }
+#judgment .QuoteChar { font-family: 'Calibri, sans-serif'; font-size: 13pt; }
+#judgment .CommentReference { font-size: 8pt; }
+#judgment .CommentTextChar { font-size: 10pt; }
+#judgment .fontstyle01 { font-style: normal; font-weight: normal; font-family: BookAntiqua; font-size: 11pt; color: #000000; }
+#judgment .CommentSubjectChar { font-weight: bold; font-family: 'Calibri, sans-serif'; font-size: 10pt; }
+</html:style>
+      </presentation>
+    </meta>
+    <header>
+      <p class="JudgmentReferences"><img src="image1.png" style="width:99.35pt;height:99.35pt"/></p>
+      <p class="JudgmentReferences"><span style="font-weight:bold;font-family:'Times New Roman'">Easter Term</span><br/><neutralCitation style="font-weight:bold;font-family:'Times New Roman'">[2024] UKSC 12</neutralCitation><br/><span style="font-style:italic;font-family:'Times New Roman'">On appeal from: </span><ref href="https://caselaw.nationalarchives.gov.uk/ewca/civ/2022/379" style="font-style:italic;font-family:'Times New Roman'" uk:canonical="[2022] EWCA Civ 379" uk:isNeutral="true" uk:origin="parser" uk:type="case">[2022] EWCA Civ 379</ref></p>
+      <p class="JudgmentTitle"><span style="font-family:'Times New Roman'">JUDGMENT</span></p>
+      <p class="JudgmentJudges"><party as="#respondent" refersTo="#secretary-of-state-for-business-and-trade" style="font-family:'Times New Roman';font-size:20pt">Secretary of State for Business and Trade</party><span style="font-family:'Times New Roman';font-size:20pt"> (</span><role refersTo="#respondent" style="font-family:'Times New Roman';font-size:20pt">Respondent</role><span style="font-family:'Times New Roman';font-size:20pt">) </span><span style="font-style:italic;font-family:'Times New Roman';font-size:20pt">v</span><span style="font-family:'Times New Roman';font-size:20pt"/><party as="#appellant" refersTo="#mercer" style="font-family:'Times New Roman';font-size:20pt">Mercer</party><span style="font-family:'Times New Roman';font-size:20pt"> (</span><role refersTo="#appellant" style="font-family:'Times New Roman';font-size:20pt">Appellant</role><span style="font-family:'Times New Roman';font-size:20pt">)</span></p>
+      <p class="JudgmentJudges"><span style="font-weight:normal;font-family:'Times New Roman'">before</span><br/><br/><judge refersTo="#judge-lord-lloyd-jones" style="font-family:'Times New Roman'">Lord Lloyd-Jones</judge><br/><judge refersTo="#judge-lord-hamblen" style="font-family:'Times New Roman'">Lord Hamblen</judge><br/><judge refersTo="#judge-lord-burrows" style="font-family:'Times New Roman'">Lord Burrows</judge><br/><judge refersTo="#judge-lord-richards" style="font-family:'Times New Roman'">Lord Richards</judge><br/><judge refersTo="#judge-lady-simler" style="font-family:'Times New Roman'">Lady Simler</judge></p>
+      <p class="JudgmentJudges"><span style="font-family:'Times New Roman'">JUDGMENT GIVEN ON</span><br/><docDate date="2024-04-17" refersTo="#judgment" style="font-family:'Times New Roman'">17 April 2024</docDate><br/><br/><span style="font-family:'Times New Roman'">Heard on 12 and 13 December 2023</span></p>
+      <p class="JudgmentAppRespInt"><span style="font-style:italic;font-family:'Times New Roman'">Appellant</span><br/><span style="font-family:'Times New Roman'">Michael Ford KC</span><br/><span style="font-family:'Times New Roman'">Stuart Brittenden</span><br/><span style="font-family:'Times New Roman'">Alan Bogg</span><br/><span style="font-family:'Times New Roman'">(Instructed by UNISON Legal Services (London))</span></p>
+      <p class="JudgmentAppRespInt"><span style="font-style:italic;font-family:'Times New Roman'">Respondent</span><br/><span style="font-family:'Times New Roman'">Daniel Stilitz KC </span><br/><span style="font-family:'Times New Roman'">Hannah Slarks</span><br/><span style="font-family:'Times New Roman'">(Instructed by Government Legal Department)</span></p>
+    </header>
+    <judgmentBody>
+      <decision>
+	<level class="author">
+	  <content>
+	    <p class="NewSpeech"><span style="text-transform:none;font-family:'Times New Roman'">LADY SIMLER (with whom Lord Lloyd-Jones, Lord Hamblen, Lord Burrows and Lord Richards agree</span><span style="font-family:'Times New Roman'">): </span></p>
+	  </content>
+	</level>
+	<level eId="lvl_1">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">Introduction</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_1">
+	  <num style="font-family:'Times New Roman';font-size:13pt">1.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Employees who are dismissed for taking part in lawful strike action have some statutory remedies for unfair dismissal but there is no express statutory (or other) protection in domestic law against action short of dismissal for employees, or indeed, workers who participate in lawful strike action. The question on this appeal is whether <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of the <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52" uk:canonical="1992 c. 52" uk:origin="TNA" uk:type="legislation">Trade Union and Labour Relations (Consolidation) Act 1992</ref> (&#8220;TULRCA&#8221;) can properly be interpreted as extending to provide such protection, and if not, what is the consequence.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_2">
+	  <num style="font-family:'Times New Roman';font-size:13pt">2.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Fiona Mercer, the appellant, was at all material times employed as a support worker in the care sector by Alternative Futures Group Ltd (&#8220;AFG&#8221;), a care services provider. As a UNISON workplace representative, she was involved in planning and took part in lawful strike action at her workplace. She was suspended by her employer. During her suspension she received normal pay, but received nothing for the overtime she would normally have worked. The effect, if not the purpose, of the suspension was also to remove her from the workplace while the industrial action was in progress. She complained to an employment tribunal that the decision to suspend her was taken for the sole or main purpose of preventing or deterring her from taking part in the activities of an independent trade union &#8220;at an appropriate time&#8221; or penalising her for having done so. Her claim was disputed as a matter of fact (her employer argued that the suspension was because she abandoned her shift without permission and spoke to the press without permission) and as a matter of law. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_3">
+	  <num style="font-family:'Times New Roman';font-size:13pt">3.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">As a matter of ordinary domestic construction, <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA has been interpreted as not providing protection from detriment short of dismissal to workers engaged in lawful strike action. This is because the words &#8220;at an appropriate time&#8221; are defined to exclude working time (save where the employer has consented to the activities in question) so that they limit the protection available to activities which are outside working time and/or not inconsistent with the worker&#8217;s performance of their primary duties to their employer. However, the appellant argues that the protection afforded by article 11 of the European Convention on Human Rights (&#8220;the Convention&#8221;) together with the strong interpretative obligation in <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42" uk:canonical="1998 c. 42" uk:origin="TNA" uk:type="legislation">Human Rights Act 1998</ref> (&#8220;the HRA&#8221;) make it possible to construe <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> compatibly with article 11 to offer extended protection to workers for detriment short of dismissal for participation in lawful strike action.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_4">
+	  <num style="font-family:'Times New Roman';font-size:13pt">4.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">This case has proceeded on assumed facts to determine the scope of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> as a preliminary question of law. It is assumed for these purposes that the decision to suspend the appellant was taken to deter her participation in lawful strike action. In the Employment Tribunal, Employment Judge Franey (who expressed well-founded reservations about whether it was appropriate to proceed in this way) held that, as a matter of domestic law, <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA does not extend protection to participation in lawful strike action and could not be interpreted compatibly, even using the <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> interpretative obligation. On appeal, the Secretary of State for Business and Trade (referred to below as &#8220;the Secretary of State&#8221;) intervened to support the Employment Tribunal&#8217;s decision. The decision was reversed by the Employment Appeal Tribunal: <ref href="#" uk:canonical="[2021] ICR 1598" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2021">[2021] ICR 1598</ref>. Choudhury J (President) held that a compatible interpretation with article 11 was both necessary and possible by adding an additional limb to the definition of &#8220;appropriate time&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref>, namely &#8220;(c) a time within working hours when he is taking part in industrial action&#8221;. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_5">
+	  <num style="font-family:'Times New Roman';font-size:13pt">5.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Secretary of State (but not the employer) appealed. In the Court of Appeal, Ms Mercer recognised that the formulation of additional limb (c) went too far because it did not qualify the type of industrial action covered. She accepted the criticism made by the Secretary of State that the EAT&#8217;s reformulated <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> went beyond any protection recognised by the European Court of Human Rights, which had been concerned only to protect lawful industrial action in appropriate circumstances. Since the mirror principle in </span><span style="font-style:italic;font-family:'Times New Roman'">R (Ullah) v Special Adjudicator</span><span style="font-family:'Times New Roman'"> <ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2004/26" uk:canonical="[2004] UKHL 26" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2004">[2004] UKHL 26</ref>, <ref href="#" uk:canonical="[2004] 2 AC 323" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2004">[2004] 2 AC 323</ref> at para 20 and </span><span style="font-style:italic;font-family:'Times New Roman'">R (Elan-Cane) v Secretary of State for the Home Department </span><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/uksc/2021/56" uk:canonical="[2021] UKSC 56" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2021">[2021] UKSC 56</ref>, <ref href="#" uk:canonical="[2023] AC 559" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2023">[2023] AC 559</ref> at para 101 requires domestic courts generally to keep pace with Strasbourg, no less but no more, it was accepted that the reading down of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> should only be applicable to industrial action which is lawful under domestic law. Accordingly, a reformulated amendment to <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> was proposed: the new subparagraph (c) added to the definition of &#8220;an appropriate time&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> should state, &#8220;(c) in respect of a detriment short of dismissal, a time within working hours when he is taking part in protected industrial action within the meaning of section 238A(1)&#8221;.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_6">
+	  <num style="font-family:'Times New Roman';font-size:13pt">6.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Court of Appeal (Lord Burnett of Maldon CJ, Bean and Singh LJJ) allowed the Secretary of State&#8217;s appeal: <ref href="https://caselaw.nationalarchives.gov.uk/ewca/civ/2022/379" uk:canonical="[2022] EWCA Civ 379" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2022">[2022] EWCA Civ 379</ref>, <ref href="#" uk:canonical="[2022] ICR 1034" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2022">[2022] ICR 1034</ref>. In summary, the court held, first, that lawful industrial action is not included within the phrase &#8220;activities of an independent trade union&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> as a matter of legislative design. Secondly, the court said that this failure to give legislative protection against any sanction short of dismissal for participation in lawful strike action may put the United Kingdom in breach of article 11 even in the case of a private sector employer, if the sanction is one which strikes at the core of trade union activity. Thirdly, however, the court held that to interpret <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> compatibly with article 11 would result in impermissible judicial legislation. Finally, the court held that it would not be appropriate to grant a declaration of incompatibility pursuant to section 4 of the HRA because the case involved a lacuna in the law rather than a specific statutory provision that was incompatible, and moreover, the extent of the incompatibility was unclear.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_7">
+	  <num style="font-family:'Times New Roman';font-size:13pt">7.</num>
+	  <intro>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The appellant now appeals with permission to the Supreme Court. The appeal is resisted by the Secretary of State. There are three grounds of appeal:</span></p>
+	  </intro>
+	  <subparagraph>
+	    <num style="font-family:'Times New Roman';font-size:13pt">(a)</num>
+	    <content>
+	      <p class="ParaApprovedLevel2" style="margin-left:0.5in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Ground 1 concerns the extent to which article 11 of the Convention protects union members against sanctions which are intended to dissuade or penalise them for taking part in taking lawful industrial action organised by their union, and whether, on the assumed facts, the UK was in breach of a positive duty to provide effective protection to the appellant through the means of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref>.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+	    <content>
+	      <p class="ParaApprovedLevel2" style="margin-left:0.5in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Ground 2 concerns whether the Court of Appeal erred in deciding that a compliant construction of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA which protects union members against being subjected to detriments because of participation in trade union activities, was not possible under <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA.</span></p>
+	    </content>
+	  </subparagraph>
+	  <subparagraph>
+	    <num style="font-family:'Times New Roman';font-size:13pt">(c)</num>
+	    <content>
+	      <p class="ParaApprovedLevel2" style="margin-left:0.5in;text-indent:0.5in"><span style="font-family:'Times New Roman'">If a compliant interpretation of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA is not possible, ground 3 concerns the question whether the Court of Appeal erred in refusing to grant a declaration of incompatibility under section 4 HRA.</span></p>
+	    </content>
+	  </subparagraph>
+	</paragraph>
+	<level eId="lvl_2">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">The legal framework</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_8">
+	  <num style="font-family:'Times New Roman';font-size:13pt">8.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">TULRCA draws a distinction between &#8220;employees&#8221; and &#8220;workers&#8221; and defines these and related expressions in sections 295 and 296 respectively. An employee is an individual who has entered into or works under a contract of service or apprenticeship. The term &#8220;worker&#8221; is a wider concept and includes an individual who works under any contract whereby he or she undertakes to do or perform personally any work or services for another party to the contract who is not their professional client. Certain protections afforded by TULRCA are limited to employees. The protection against dismissal in circumstances discussed below in section 152 is only available to employees. Other protections are afforded to workers, and <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> is an example.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_9">
+	  <num style="font-family:'Times New Roman';font-size:13pt">9.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Part III of TULRCA concerns rights in relation to union membership and activities. <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 146</ref> in Part III is central to this appeal. It is headed &#8220;Detriment on grounds related to union membership or activities&#8221; and, so far as relevant, provides:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(1)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">A worker has the right not to be subjected to any detriment as an individual by any act, or any deliberate failure to act, by his employer if the act or failure takes place for the sole or main purpose of &#8211; </span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(a)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">...</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">preventing or deterring him from taking part in the activities of an independent trade union at an appropriate time, or penalising him for doing so ...&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_10">
+	  <num style="font-family:'Times New Roman';font-size:13pt">10.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">What is an &#8220;appropriate time&#8221; is defined in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> as follows: </span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(2)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In subsection (1), &#8216;an appropriate time&#8217; means &#8211; </span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(a)</num>
+		  <intro>
+		    <p class="Quote" style="margin-left:1in;text-indent:1in"><span style="font-family:'Times New Roman'">a time outside the worker&#8217;s working hours, or </span></p>
+		  </intro>
+		  <subparagraph>
+		    <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+		    <content>
+		      <p class="Quote" style="margin-left:1.5in;text-indent:0.5in"><span style="font-family:'Times New Roman'">a time within his working hours at which, in accordance with arrangements agreed with or consent given by his employer, it is permissible for him to take part in the activities of a trade union ...;</span></p>
+		    </content>
+		  </subparagraph>
+		  <wrapUp>
+		    <p class="Quote" style="margin-left:1in"><span style="font-family:'Times New Roman'">and for this purpose &#8216;working hours&#8217;, in relation to a worker, means any time when, in accordance with his contract of employment (or other contract personally to do work or perform services), he is required to be at work.&#8221;</span></p>
+		  </wrapUp>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_11">
+	  <num style="font-family:'Times New Roman';font-size:13pt">11.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The remedy for a breach of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> is a complaint to an employment tribunal under section 147. If the tribunal finds that the complaint is well-founded, it makes a declaration to that effect and may make an award of compensation (including for injury to feelings) under section 149 of TULRCA. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_12">
+	  <num style="font-family:'Times New Roman';font-size:13pt">12.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Section 152 provides corresponding protection against dismissal (as opposed to detriment short of dismissal)</span><span style="font-family:'Times New Roman';color:#232323"> and is in similar terms. It makes it </span><span style="font-family:'Times New Roman'">automatically unfair to dismiss an employee (but not a worker who is not an employee) for the same proscribed reasons, including taking part in trade union activities at an appropriate time:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(1)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">For the purposes of Part X of the <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18" uk:canonical="1996 c. 18" uk:origin="TNA" uk:type="legislation">Employment Rights Act 1996</ref> (unfair dismissal) the dismissal of an employee shall be regarded as unfair if the reason for it (or, if more than one, the principal reason) was that the employee -</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(a)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">&#8230;</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">had taken part, or proposed to take part, in the activities of an independent trade union at an appropriate time&#8230;&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_13">
+	  <num style="font-family:'Times New Roman';font-size:13pt">13.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">&#160;Section 152(2) defines &#8220;an appropriate time&#8221; in the same way as <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref>, but because this provision concerns rights conferred only on employees, the wording of the definition of working hours is slightly different. Neither side suggests that anything turns on that distinction for present purposes.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_14">
+	  <num style="font-family:'Times New Roman';font-size:13pt">14.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Part III of TULRCA also contains provisions dealing with time off for trade union duties and activities. For example, section 170 provides so far as material:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(1)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">An employer shall permit an employee of his who is a member of an independent trade union recognised by the employer in respect of that description of employee to take time off during his working hours for the purpose of taking part in &#8211; </span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(a)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">any activities of the union, and</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">any activities in relation to which the employee is acting as a representative of the union.</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(2)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The right conferred by subsection (1) does not extend to activities which themselves consist of industrial action, whether or not in contemplation or furtherance of a trade dispute.&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_15">
+	  <num style="font-family:'Times New Roman';font-size:13pt">15.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Part IV of TULRCA is concerned with industrial relations but none of its provisions are directly relevant to this appeal.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_16">
+	  <num style="font-family:'Times New Roman';font-size:13pt">16.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Part V of TULRCA is headed &#8220;Industrial Action&#8221;. It contains the conditions with which a trade union must comply before calling industrial action to attract the statutory immunity from civil action by the employer that is available under the so-called &#8220;golden formula&#8221; in section 219. At common law, almost any form of strike or industrial action amounts to a repudiatory breach of contract, entitling the employer summarily to dismiss striking workers, to withhold their pay, to impose disciplinary sanctions or to sue individual strikers for damages. In addition, a union calling industrial action will almost invariably commit an economic tort, typically inducing breach of contract, making it liable to an action for an injunction or a claim for damages. By section 219 of TULRCA (dating back to the Trade Disputes Act of 1906) a trade union is given immunity in respect of certain economic torts. The immunity is restricted both substantively and procedurally in important respects. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_17">
+	  <num style="font-family:'Times New Roman';font-size:13pt">17.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Substantively, it only applies if the strike is &#8220;in contemplation or furtherance of a trade dispute&#8221; (as defined in section 244 by reference to matters relating to terms and conditions of employment and the like). Further, it does not apply to some forms of industrial action, including &#8220;secondary&#8221; action, where the target of the strike is an employer who is not a party to the trade dispute. Procedurally, the immunity only applies if the union has complied with a series of detailed statutory rules on balloting, providing information to the employer and notice requirements: see section 219(4). Among other things, the union must send the employer information about the numbers, categories and workplaces of those to be balloted (section 226A); appoint an independent scrutineer (section 226B); hold a postal ballot (sections 227 to 230); not strike unless 50% of those members entitled to vote have cast a vote with a simple majority in favour (and in certain public sector employments, this must be at least 40% of those entitled to vote) (section 226); provide the members and employer with the result of the ballot (sections 231 to 231A); obtain a scrutineer&#8217;s report (section 231B); ensure that only the specified person calls for action (section 233); not take action outside the period of the effectiveness of the ballot (section 234); and give advance notice to the employer containing prescribed information about the workers whom the union believes will take part in the action (section 234A). A breach of any of these provisions deprives the union of its trade dispute immunity. It also has the effect that the action is not &#8220;protected&#8221; for the purpose of protection from dismissal, otherwise automatically unfair by virtue of section 238A described below. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_18">
+	  <num style="font-family:'Times New Roman';font-size:13pt">18.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In addition, Part V of TULRCA contains provisions governing the statutory right to claim unfair dismissal for those dismissed while taking part in industrial action. In short summary, employees taking part in unauthorised (or unofficial) industrial action have no right to complain of unfair dismissal, save in limited circumstances (section 237) which do not include dismissal for trade union activities under section 152. Where the industrial action is official, the right to complain of unfair dismissal is limited to two situations (section 238). The first is where the employer engages in selective dismissals (retaining other striking employees in the same position or swiftly re-engaging them after dismissal). The second is where the reason or principal reason for dismissal is one of a small number of automatically unfair reasons (but the reasons specified do not include dismissal because of trade union activities under section 152, although they do include dismissal because of taking official industrial action to which section 238A applies). Section 238A applies to employees dismissed for taking part in &#8220;protected industrial action&#8221;. Such a dismissal is automatically unfair where the dismissal takes place within a &#8220;protected period&#8221;, in general 12 weeks from the first day of industrial action, but it can extend for a longer period where the employer does not take reasonable procedural steps to resolve the strike. &#8220;Protected industrial action&#8221; means industrial action in respect of which the union has immunity in tort because it has complied with the substantive and procedural statutory rules contained in Part V of TULRCA. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_19">
+	  <num style="font-family:'Times New Roman';font-size:13pt">19.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Industrial action potentially engages both articles 10 and 11 of the Convention, but article 11 is usually treated as the lex specialis for trade union organised industrial action.</span><span style="font-style:italic;font-family:'Times New Roman'"/><span style="font-family:'Times New Roman'">Article 11 protects two distinct but linked rights: freedom of assembly and freedom of association. Both rights relate to individuals coming together to express and protect their common interests. Lawful industrial action typically engages both rights. Article 11 provides:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(1)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Everyone has the right to freedom of peaceful assembly and to freedom of association with others, including the right to form and to join trade unions for the protection of his interests.</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(2)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">No restrictions shall be placed on the exercise of these rights other than such as are prescribed by law and are necessary in a democratic society in the interests of national security or public safety, for the prevention of disorder or crime, for the protection of health or morals or for the protection of the rights and freedoms of others. This Article shall not prevent the imposition of lawful restrictions on the exercise of these rights by members of the armed forces, of the police or of the administration of the State.&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_20">
+	  <num style="font-family:'Times New Roman';font-size:13pt">20.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Both articles were given effect in domestic law by section 1 of the HRA. Section 2(1) of the HRA provides:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<level>
+		  <content>
+		    <p class="Quote" style="margin-left:1in"><span style="font-family:'Times New Roman'">&#8220;A court or tribunal determining a question which has arisen in connection with a Convention right must take into account any &#8230; judgment, decision, declaration or advisory opinion of the European Court of Human Rights &#8230; whenever made or given, so far as, in the opinion of the court or tribunal, it is relevant to the proceedings in which that question has arisen.&#8221;</span></p>
+		  </content>
+		</level>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_21">
+	  <num style="font-family:'Times New Roman';font-size:13pt">21.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'"><ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 3</ref> is headed &#8220;Interpretation of legislation&#8221; and reads as follows:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(1)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">So far as it is possible to do so, primary legislation and subordinate legislation must be read and given effect in a way which is compatible with the Convention rights.</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(2)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">This section -</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(a)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">applies to primary legislation and subordinate legislation whenever enacted;</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">does not affect the validity, continuing operation or enforcement of any incompatible primary legislation; and</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(c)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">does not affect the validity, continuing operation or enforcement of any incompatible subordinate legislation if (disregarding any possibility of revocation) primary legislation prevents removal of the incompatibility.&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_22">
+	  <num style="font-family:'Times New Roman';font-size:13pt">22.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Section 4 of the HRA empowers the senior courts to make a declaration that a provision is incompatible with a Convention right. So far as material it provides:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(1)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Subsection (2) applies in any proceedings in which a court determines whether a provision of primary legislation is compatible with a Convention right.</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(2)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">If the court is satisfied that the provision is incompatible with a Convention right, it may make a declaration of that incompatibility.&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_23">
+	  <num style="font-family:'Times New Roman';font-size:13pt">23.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">By section 4(6) of the HRA, a declaration of incompatibility does not affect the continuing validity of the relevant provision and nor is it binding on the parties in the proceedings.</span></p>
+	  </content>
+	</paragraph>
+	<level eId="lvl_3">
+	  <content>
+	    <p class="ParaHeading1"><span style="font-family:'Times New Roman'">T</span><span style="text-transform:none;font-family:'Times New Roman'">he facts and the lower courts&#8217; reasoning in more detail</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_24">
+	  <num style="font-family:'Times New Roman';font-size:13pt">24.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The appellant was employed as a support worker by AFG from 2009 and was a workplace representative for UNISON, the recognised union for collective bargaining with AFG on behalf of its members. Her employment ceased in 2022.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_25">
+	  <num style="font-family:'Times New Roman';font-size:13pt">25.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In early 2019 there was a trade dispute between AFG and UNISON about the removal of &#8220;top-up&#8221; payments for sleep-in shifts at AFG&#8217;s care homes. UNISON went through the procedural requirements in Part V of TULRCA relating to balloting and notification, and called a series of strikes which ran intermittently between 2 March and 14 May 2019. The appellant was involved in planning and took part in the industrial action. She was interviewed by iNews in connection with the strike, in January 2019, and press material appeared in the Liverpool Echo in late March 2019. She also participated in the strikes herself.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_26">
+	  <num style="font-family:'Times New Roman';font-size:13pt">26.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">On 26 March 2019 she was suspended. She was told this was because of allegations that she had abandoned her shift on two separate occasions without permission, and that she had spoken to the press about the strike action without prior authorisation in a way which conveyed confidential information and was considered likely to bring AFG into disrepute. The suspension was lifted on 11 April 2019, but disciplinary action against her continued. On 26 April 2019 the appellant was given a first written warning for leaving her shift. That sanction was overturned on appeal. A grievance which she filed in June 2019 was rejected, and an appeal against that decision was also unsuccessful.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_27">
+	  <num style="font-family:'Times New Roman';font-size:13pt">27.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">On 23 August 2019, the appellant presented a claim to the employment tribunal contending (among other things) that she had been subjected to a detriment when she was suspended, and this was done for the sole or main purpose of preventing or deterring her from taking part in the activities of an independent trade union at &#8220;an appropriate time&#8221; or penalising her for having done so. Her case was that the &#8220;activities&#8221; encompassed both the planning and organisation of the industrial action and her own participation in it.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_28">
+	  <num style="font-family:'Times New Roman';font-size:13pt">28.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">AFG&#8217;s response dated 28 October 2019 defended her complaint on its merits. Further, although AFG conceded that planning or organising industrial action could fall within the scope of union activities in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA, so long as it took place at an appropriate time, it contended that taking part in industrial action was not an activity protected by <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_29">
+	  <num style="font-family:'Times New Roman';font-size:13pt">29.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Because the claim proceeded on assumed facts, no causation (or any other) findings were made, including with respect to AFG&#8217;s motives in suspending and pursuing disciplinary proceedings against the appellant, nor about the reasonableness or proportionality of its actions. It is common ground, however, that the strike action was official primary action in relation to a trade dispute with the employer and therefore, protected, and lawful. I shall describe such action simply as &#8220;lawful industrial or strike action&#8221; below. On the assumed facts, the purpose of the suspension and other treatment was to prevent or deter the appellant from participating in it. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_30">
+	  <num style="font-family:'Times New Roman';font-size:13pt">30.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">By a judgment dated 4 May 2020, EJ Franey dismissed that part of the appellant&#8217;s complaint under <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> which was based on participation in lawful strike action. In EJ Franey&#8217;s judgment, it was not possible under <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA to interpret <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA as including participation in a lawful strike given that the grain of the legislation was to draw a distinction between trade union activities and industrial action. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_31">
+	  <num style="font-family:'Times New Roman';font-size:13pt">31.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The appellant&#8217;s appeal to the EAT was allowed by a judgment dated 2 June 2021. Choudhury J&#8217;s reasoning in summary, proceeded as follows. First, as a matter of ordinary statutory construction the phrase &#8220;the activities of an independent trade union&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/1" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(1)</ref>(b) of TULRCA could not be interpreted to include participation in industrial action sanctioned by a union. Secondly, the Strasbourg jurisprudence demonstrated that the right to strike, though not an essential element of the right to freedom of association in article 11, was clearly protected by it and that a narrower margin applied where it was alleged that there was a lack of protection in respect of participation in primary or direct industrial action. The failure of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> to encompass industrial action gave rise to an interference with the appellant&#8217;s article 11 rights, and no legislative objective had been identified that was important enough to justify the limitation on that right, nor was there a fair balance between the competing interests of workers seeking to exercise their trade union rights and those of the employer and the wider community. </span><span style="font-family:'Times New Roman';color:#1C1C1C">Thirdly, </span><span style="font-family:'Times New Roman'"><ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> could permissibly be interpreted differently from section 152 by virtue of the obligation in <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA. Given the legislative history of these two provisions, neither the &#8220;grain&#8221; of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> nor its wording precluded an article 11-compliant construction of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref>. Choudhury J therefore read into <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> the new subparagraph to which I have referred, extending the definition of an &#8220;appropriate time&#8221; to &#8220;</span><span style="font-family:'Times New Roman';color:#1C1C1C">(c) a time within working hours when he is taking part in industrial action.&#8221;</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_32">
+	  <num style="font-family:'Times New Roman';font-size:13pt">32.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">AFG did not seek to appeal against the EAT decision but, in view of the finding that <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> had to be read compatibly with article 11 of the Convention to afford protection for action short of dismissal for striking workers, the Secretary of State, as intervener, applied for and was granted permission to appeal (on terms that the Secretary of State was not entitled to recover costs against any other party whatever the outcome of the appeal).</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_33">
+	  <num style="font-family:'Times New Roman';font-size:13pt">33.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Secretary of State&#8217;s appeal was allowed. The Court of Appeal agreed with the EAT that, on ordinary domestic principles of statutory interpretation, the phrase &#8220;activities of an independent union&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/1" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(1)</ref> of TULRCA did not include participation in industrial action and it followed that <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> did not provide protection against detriment short of dismissal for taking part in or organising official or lawful industrial action. As regards article 11, the Court of Appeal noted it was common ground that an employee had no right to be paid for the time on strike under article 11. The Court of Appeal did not accept, however, that all other detriments imposed in response to any industrial action necessarily contravened article 11. Rather, following the decision of the Strasbourg court in </span><span style="font-style:italic;font-family:'Times New Roman'">National Union of Rail, Maritime and Transport Workers v United Kingdom</span><span style="font-family:'Times New Roman'"> <ref href="#" uk:canonical="(2014) 60 EHRR 10" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2014">(2014) 60 EHRR 10</ref> (&#8220;</span><span style="font-style:italic;font-family:'Times New Roman'">RMT</span><span style="font-family:'Times New Roman'">&#8221;), only primary industrial action sanctioned by a trade union had to be afforded protection. Further, Strasbourg case law does not establish that the state&#8217;s positive obligations under article 11 require that private employers should be unconditionally prohibited from treating workers detrimentally on the ground of having participated in industrial action. On the other hand, nor did the Court of Appeal accept that, where the interference was by a private sector employer, the state owed </span><span style="font-style:italic;font-family:'Times New Roman'">no</span><span style="font-family:'Times New Roman'"> positive obligations to secure article 11 rights, expressing agreement with the EAT in this regard. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_34">
+	  <num style="font-family:'Times New Roman';font-size:13pt">34.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Court of Appeal's conclusion at para 71 was that: &#8220;the failure to give legislative protection against any sanction short of dismissal for official industrial action against the employees who take it may put the United Kingdom in breach of article 11 even in the case of a private sector employer, if the sanction is one which strikes at the core of trade union activity.&#8221; However, it emphasised there had been no findings of fact about the employer&#8217;s motive or the proportionality of its actions in relation to the appellant&#8217;s claim in this case. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_35">
+	  <num style="font-family:'Times New Roman';font-size:13pt">35.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">On the question whether it was possible to interpret <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> TULRCA compatibly with article 11 by qualifying the definition of an &#8220;appropriate time&#8221; in a new <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref>(c), to protect workers from detriments short of dismissal for taking &#8220;protected industrial action&#8221; in working hours, the Court of Appeal held that it was not possible to do so. While Strasbourg case law has consistently protected lawful industrial action, the extent and duration of the protection that should be provided compatibly with article 11, at least in a private sector case, was uncertain. These were policy issues best left for Parliament, the determination of which by the courts would amount to impermissible judicial legislation beyond the scope of <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_36">
+	  <num style="font-family:'Times New Roman';font-size:13pt">36.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Having reached that conclusion, the Court of Appeal considered whether it should grant a declaration of incompatibility under section 4 of the HRA and decided not to do so. The Court of Appeal acknowledged that in </span><span style="font-style:italic;font-family:'Times New Roman'">Bellinger v Bellinger (Lord Chancellor intervening) </span><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2003/21" uk:canonical="[2003] UKHL 21" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2003">[2003] UKHL 21</ref>, <ref href="#" uk:canonical="[2003] 2 AC 467" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2003">[2003] 2 AC 467</ref>, the House of Lords made a declaration of incompatibility in respect of a lacuna in a statute. However, the Court of Appeal also considered </span><span style="font-style:italic;font-family:'Times New Roman'">In re S (Minors) (Care Order: Implementation of Care Plan)</span><span style="font-family:'Times New Roman'"> <ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2002/10" uk:canonical="[2002] UKHL 10" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] UKHL 10</ref>, <ref href="#" uk:canonical="[2002] 2 AC 291" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] 2 AC 291</ref> and decided it was not appropriate to make a declaration where &#8220;there is a lacuna in the law rather than a specific statutory provision which is incompatible&#8230;., the extent of the incompatibility is unclear and the legislative choices are far from being binary questions&#8221;.</span></p>
+	  </content>
+	</paragraph>
+	<level eId="lvl_4">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">Overview of the parties&#8217; respective cases </span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_37">
+	  <num style="font-family:'Times New Roman';font-size:13pt">37.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">On behalf of the appellant, Mr Ford KC submits that the Strasbourg jurisprudence has consistently interpreted article 11 as protecting trade union members who are subject to sanctions, however minimal, intended to deter or penalise participation in lawful industrial action organised by their union for the purpose of protecting their professional interests. This applies a fortiori to detriments like suspension, imposed on union officials who organise a lawful strike. Such sanctions have an inevitable chilling effect on trade union members participating in lawful industrial action. Mr Ford relied on cases such as </span><span style="font-style:italic;font-family:'Times New Roman'">Ezelin v France</span><span style="font-family:'Times New Roman'"> <ref href="#" uk:canonical="(1991) 14 EHRR 362" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="1991">(1991) 14 EHRR 362</ref>, where a minor reprimand of a lawyer for participating in a protest against the judiciary was held to have contravened article 11 for this reason. The same approach is seen in several subsequent cases including </span><span style="font-style:italic;font-family:'Times New Roman'">Kara&#231;ay v Turkey</span><span style="font-family:'Times New Roman'"> (Application No 6615/03) (unreported) 27 March 2007, at paras 35 to 37, </span><span style="font-style:italic;font-family:'Times New Roman'">Danilenkov v Russia</span><span style="font-family:'Times New Roman'"> <ref href="#" uk:canonical="(2009) 58 EHRR 19" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2009">(2009) 58 EHRR 19</ref>, at paras 124 and 136, </span><span style="font-style:italic;font-family:'Times New Roman'">Kaya v Turkey</span><span style="font-family:'Times New Roman'"> (Application No 30946/04) (unreported) 15 September 2009, at paras 29 to 31 and </span><span style="font-style:italic;font-family:'Times New Roman'">Ognevenko v Russia</span><span style="font-family:'Times New Roman'"> <ref href="#" uk:canonical="(2018) 69 EHRR 9" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2018">(2018) 69 EHRR 9</ref>. Mr Ford submitted that in every case where interferences of this kind have been considered by the Strasbourg court, they have been found to be unjustified infringements of article 11.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_38">
+	  <num style="font-family:'Times New Roman';font-size:13pt">38.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">He submitted that there is no difference in approach between cases involving the state, acting as an employer, directly interfering with article 11 rights, and cases involving private sector employers where the state has failed positively to legislate to provide effective legal redress for workers who are subject to sanctions in these circumstances. Lawful strike action is a core trade union activity that attracts article 11 protection, and such sanctions strike at a core union activity. On the assumed facts, the state owed a positive duty to afford the appellant effective redress for detriment that struck directly at the core of article 11; and a narrower rather than a wider margin applies. While the Court of Appeal accepted the absence of remedies in domestic law might well be in breach of article 11 in some circumstances, it did not recognise that UK law must protect against any sanction, however light, intended to dissuade members from taking part in lawful industrial action.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_39">
+	  <num style="font-family:'Times New Roman';font-size:13pt">39.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">At the domestic level, <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA protects individuals against being subjected to detriments for participation in trade union activities and is the sole vehicle by which the appellant could vindicate her article 11 rights. The barriers to a Convention-compliant construction are surmountable as the EAT held. First, the result from article 11 is clear &#8211; national law must provide real and effective protection against sanctions as identified in </span><span style="font-style:italic;font-family:'Times New Roman'">Kara&#231;ay</span><span style="font-family:'Times New Roman'">. If there is any uncertainty about that test, it is resolved by principles established by the International Labour Organisation (&#8220;ILO&#8221;) and European Social Charter (&#8220;ESC&#8221;) which require protection against any harmful consequence or prejudice to a worker by reason of trade union activities. Secondly, the thrust of the legislation is that lawful strike action is a legitimate trade union activity, and the specific thrust of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> is to protect freedom of association. The genesis of the statutory protection was to bring domestic law into line with ILO Convention No 98 1949 on the Application of the Principles of the Right to Organise and to Bargain Collectively (&#8220;the ILO Convention&#8221;), which protects workers against being subjected to sanctions or dismissal for taking part in strikes (and informs the content of article 11). The UK Government&#8217;s declared intention in 2004 (before amendments to the legislation were enacted) was to comply with article 11. The distinct legislative provision for unfair dismissal is no bar to a compliant construction of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> to protect union members against action short of dismissal.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_40">
+	  <num style="font-family:'Times New Roman';font-size:13pt">40.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Court of Appeal&#8217;s reasons for rejecting a conforming interpretation were that policy questions were involved, and more than one legislative solution was possible. But considering the consistent Strasbourg jurisprudence and the domestic &#8220;mirror&#8221; principle, the potential policy questions raised by the Court of Appeal do not arise: Parliament has already addressed the social and economic policy issues in defining what lawful industrial action is in the UK; and domestic law must provide effective protection to the individual regardless of the type of detriment to which the worker or union official is subjected. The court can and should read in the following wording to the definition of &#8220;an appropriate time&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">s146(2)</ref> of TULRCA: &#8220;(c) in respect of a detriment short of dismissal, a time within working hours when he is taking part in protected industrial action within the meaning of section 238A(1).&#8221; </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_41">
+	  <num style="font-family:'Times New Roman';font-size:13pt">41.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">If a compliant construction is not possible, the Court of Appeal erred in declining to make a declaration of incompatibility under section 4 of the HRA. The purpose of the HRA, in &#8220;bringing rights home&#8221;, indicates that it should be an unusual or exceptional case where an incompatibility is found without making a section 4 declaration. A refusal to do so deprives Parliament of the opportunity to introduce speedy remedial legislation. The Court of Appeal wrongly treated the claim as one for a declaration that TULRCA as a whole was incompatible with article 11, whereas the target is the exclusion of participation in industrial action from the scope of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> as intrinsically incompatible with article 11. The Court of Appeal&#8217;s analysis of existing authorities was misplaced, and it wrongly treated the existence of legislative choices in giving effect to article 11 as a reason not to make a declaration rather than a reason in favour. In circumstances where <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> is intrinsically incompatible with article 11 a declaration should have been made. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_42">
+	  <num style="font-family:'Times New Roman';font-size:13pt">42.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">For the Secretary of State (intervening), Mr Stilitz KC submits that article 11 does not require legislation affording universal protection to workers in respect of any detrimental action by an employer against a worker for taking lawful industrial action. The Strasbourg jurisprudence has not gone so far as to say that any sanction imposed on a worker for participating in such industrial action gives rise to a breach of article 11. In the case law concerning detrimental action by employers in response to strike action, the Strasbourg court has found violations of article 11 only when there has been direct state interference to prevent collective bargaining, or the employer has been a state body imposing sanctions or shutting out the union altogether. This reflects the well-established principle that the state is owed a wider margin of appreciation in respect of its positive obligation to regulate and balance the competing rights of employers and workers than in respect of its negative obligation not directly to infringe individual rights as an employer.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_43">
+	  <num style="font-family:'Times New Roman';font-size:13pt">43.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The UK has a wide margin of appreciation in determining how to balance the interests of workers and employers. The limited protection provided by <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref>, read with the other protections afforded to striking workers under TULRCA and more generally, is compatible with article 11, striking a fair balance between the rights of employers and workers. Even if that is not accepted, redrafting <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> would involve an exercise of judicial legislation, requiring the court to determine for itself many difficult policy questions. Further, the interpretation of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> that is contended for cannot be reconciled with fundamental features of TULRCA. Finally, and in any event, the court cannot use section 4 of the HRA to declare that either <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> specifically or TULRCA in general is incompatible with Convention rights because if there is any incompatibility between the statutory regime and Convention rights (which the Secretary of State denies), this arises from a lacuna in the overall legislative scheme, which cannot be attributed to any one provision. The HRA sets out an exhaustive set of remedies, and in the case of a challenge to legislation, only <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">sections 3</ref> and 4 are available. Since neither is available here, the appellant would have to seek her remedy from the Strasbourg court. </span></p>
+	  </content>
+	</paragraph>
+	<level eId="lvl_5">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">The domestic construction of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref></span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_44">
+	  <num style="font-family:'Times New Roman';font-size:13pt">44.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Like the courts below, I consider that read in isolation and as a matter of ordinary language the phrase &#8220;activities of an independent trade union&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/1" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(1)</ref> of TULRCA is apt to include participation in, or the organisation of, lawful strike action. However, the phrase cannot be read in isolation. In </span><span style="font-style:italic;font-family:'Times New Roman'">Drew v St Edmundsbury Borough Council </span><span style="font-family:'Times New Roman'"><ref href="#" uk:canonical="[1980] ICR 513" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="1980">[1980] ICR 513</ref> Slynn J (then President of the EAT), explained (pp 517G -518A):</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<level>
+		  <content>
+		    <p class="Quote" style="margin-left:1in"><span style="font-family:'Times New Roman'">&#8220;But the tribunal &#8230; considered that there was a distinction between the activities of an independent trade union and taking part in a strike or other industrial action. It was their view, that if what happened was taking part in industrial action, then it could not be a trade union activity for the purposes of <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/58" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 58</ref> of <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18" uk:canonical="1996 c. 18" uk:origin="TNA" uk:type="legislation">the Act</ref> [the predecessor of <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref>] whatever might be the position as a matter of ordinary language. </span></p>
+		  </content>
+		</level>
+		<level>
+		  <content>
+		    <p class="Quote" style="margin-left:1in"><span style="font-family:'Times New Roman'">&#8230; </span><span style="font-style:italic;font-family:'Times New Roman'">Under <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/58" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 58</ref>, if an employer dismisses because a man has taken part in the activities of an independent trade union, then the dismissal is unfair. Under section 62, if an employee takes part in a strike or other industrial action, the position is entirely different</span><span style="font-family:'Times New Roman'">. There, a man is not entitled to bring a claim that he has been unfairly dismissed when at the date of his dismissal he was taking part in a strike or other industrial action, unless he can show that other employees who, to put it broadly, were taking part in industrial action were not dismissed at the same time, or, if some were offered re-engagement, that he was one who was not. </span><span style="font-style:italic;font-family:'Times New Roman'">It is quite impossible &#8230; for the same person to fall under both of those sections. Accordingly, it seems to us quite clear that there is intended by Parliament to be a distinction for the purposes of a claim of unfair dismissal between what is an activity of an independent trade union and taking part in industrial action. It seems to us that that distinction is borne out, for the purpose of the legislation, when one considers the terms of <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/23" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 23</ref> and <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/28/1" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 28(1)</ref> of <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18" uk:canonical="1996 c. 18" uk:origin="TNA" uk:type="legislation">the Act</ref> which are dealing with trade union membership and activities and time off for trade union activities.</span><span style="font-family:'Times New Roman'"> &#8230;&#8221; (Emphasis added)</span></p>
+		  </content>
+		</level>
+	      </embeddedStructure></block>
+	    <p class="ParaNoNumber"><span style="font-family:'Times New Roman'">Neither side in this case has suggested that the analysis in </span><span style="font-style:italic;font-family:'Times New Roman'">Drew</span><span style="font-family:'Times New Roman'"> is wrong as a matter of domestic law. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_45">
+	  <num style="font-family:'Times New Roman';font-size:13pt">45.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">It seems to me that it is supported by the requirement in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/1" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(1)</ref> that the activity must be carried out &#8220;at an appropriate time&#8221; to qualify for protection. The phrase, &#8220;at an appropriate time&#8221; is defined as meaning outside working hours, or within those hours where the employer consents: see <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref>. Industrial action will normally be carried out during working hours if it is to have the desired effect since to withhold labour at a time when the employer has no expectation of labour being provided is unlikely to have any consequence. Although as both tribunals below noted, there are some forms of industrial action (for example, refusing to work voluntary overtime beyond contracted working hours) that would, on the face of it, be carried out outside working hours and therefore &#8220;at an appropriate time&#8221;, the intention is plainly to limit that protection to activities which are not inconsistent with the performance by workers of primary duties owed to the employer.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_46">
+	  <num style="font-family:'Times New Roman';font-size:13pt">46.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">This conclusion is reinforced by considering the wider scheme of TULRCA, and the limited protection available to individuals who participate in lawful industrial action in Part V (sections 237 to 238A) of TULRCA. This detailed scheme allows an employer lawfully to dismiss an employee for participating in industrial action where the action is unofficial; or dismissal is not selective (unless section 238A applies); or the employer waits for a period of 12 weeks after the commencement of industrial action. There is, accordingly, no universal protection provided to workers against dismissal for participating in industrial action, although plainly the conditions in which such a dismissal is lawful are limited.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_47">
+	  <num style="font-family:'Times New Roman';font-size:13pt">47.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">By contrast, separate protection against dismissal for participating in the activities of a trade union at an appropriate time (the parallel provision to <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref>) is contained in <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> of TULRCA. To construe <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> as including lawful industrial action in working hours would mean that an employee dismissed for engaging in industrial action at an appropriate time could bring a claim for unfair dismissal under <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> and thereby avoid the carefully constructed regime giving limited protection for dismissals in sections 237 to 238A. For the reasons given in </span><span style="font-style:italic;font-family:'Times New Roman'">Drew</span><span style="font-family:'Times New Roman'">, that cannot be right: an employee dismissed for taking part in industrial action cannot fall within both <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> and sections 237 to 238A of TULRCA at the same time. Otherwise, the employee would be entitled to a finding of automatic unfair dismissal under the former provision but would be subject to the limited protections against unfair dismissal under the latter, and the regime in sections 237 to 238A would be redundant. Given that <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> operates by reference to &#8220;an appropriate time&#8221; it is plainly to be interpreted as not encompassing dismissal for industrial action. It follows that on ordinary principles of statutory interpretation, <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> does not provide protection against detriment short of dismissal for workers taking part in industrial action. </span></p>
+	  </content>
+	</paragraph>
+	<level eId="lvl_6">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">The legislative history of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">sections 146</ref> and 152 TULCRA</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_48">
+	  <num style="font-family:'Times New Roman';font-size:13pt">48.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The legislative history of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">sections 146</ref> and 152 of TULRCA also supports this conclusion, confirming that these are sibling provisions, which should be interpreted consistently with each other (contrary to the view expressed by the EAT). Both sections are originally derived from article 1 of the ILO Convention which provides:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;1.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Workers shall enjoy adequate protection against acts of anti-union discrimination in respect of their employment.</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">2.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Such protection shall apply more particularly in respect of acts calculated to -</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(a)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">make the employment of a worker subject to the condition that he shall not join a union or shall relinquish trade union membership;</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">cause the dismissal of or otherwise prejudice a worker by reason of union membership or </span><span style="font-style:italic;font-family:'Times New Roman'">because of participation in union activities outside working hours or, with the consent of the employer, within working hours</span><span style="font-family:'Times New Roman'">.&#8221; (emphasis added)</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_49">
+	  <num style="font-family:'Times New Roman';font-size:13pt">49.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In 1965 a Royal Commission on Trade Unions and Employers&#8217; Associations was appointed to &#8220;consider relations between managements and employees and the role of trade unions and employers&#8217; associations in promoting the interests of their members and in accelerating the social and economic advance of the nation, with particular reference to the Law affecting the activities of these bodies&#8221;. It was chaired by Lord Donovan and reported in 1968 (Cmnd 3623). The Donovan Report, as it became known, recommended changes in the law to make it consistent with the ILO Convention, and a new regime of protection against unfair dismissal. However, it did not recommend protection against either dismissal or action short of dismissal in respect of the right to strike. The recommendations of the Donovan Report were taken forward by means of the <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">Industrial Relations Act 1971</ref> (&#8220;<ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">the 1971 Act</ref>&#8221;). </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_50">
+	  <num style="font-family:'Times New Roman';font-size:13pt">50.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'"><ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">The 1971 Act</ref> was enacted against the background of increasingly intense industrial discord across the country. It did not include protection against either dismissal or detriment short of dismissal for striking. Consistently with both the ILO Convention and the Donovan Report, only activities &#8220;at any appropriate time&#8221; were protected. <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72/section/5" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 5</ref> of <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">the 1971 Act</ref></span><span style="font-weight:bold;font-family:'Times New Roman'"/><span style="font-family:'Times New Roman'">was the first precursor to <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">sections 146</ref> and 152. So far as relevant, it provided:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(1)</num>
+		  <intro>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Every worker shall, as between himself and his employer, have the following rights, that is to say, -</span></p>
+		  </intro>
+		  <subparagraph>
+		    <content>
+		      <p class="Quote" style="margin-left:1.5in"><span style="font-family:'Times New Roman'">&#8230;(c) where he is a member of a trade union, the right, at any appropriate time, to take part in the activities of the trade union (including any activities as, or with a view to becoming, an official of the trade union) and the right to seek or accept appointment or election, and (if appointed or elected) to hold office, as such an official.</span></p>
+		    </content>
+		  </subparagraph>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">(2)</num>
+		  <intro>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">It shall accordingly be an unfair industrial practice for any employer, or for any person acting on behalf of an employer, -</span></p>
+		  </intro>
+		  <subparagraph>
+		    <num style="font-family:'Times New Roman';font-size:13pt">(a)</num>
+		    <content>
+		      <p class="Quote" style="margin-left:1.5in;text-indent:0.5in"><span style="font-family:'Times New Roman'">to prevent or deter a worker from exercising any of the rights conferred on him by subsection (1) of this section, or</span></p>
+		    </content>
+		  </subparagraph>
+		  <subparagraph>
+		    <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+		    <content>
+		      <p class="Quote" style="margin-left:1.5in;text-indent:0.5in"><span style="font-family:'Times New Roman'">to dismiss, penalise or otherwise discriminate against a worker by reason of his exercising any such right or &#8230;&#8221;</span></p>
+		    </content>
+		  </subparagraph>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_51">
+	  <num style="font-family:'Times New Roman';font-size:13pt">51.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Consistently with the ILO Convention, <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72/section/5/5" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 5(5)</ref> defined &#8220;appropriate time&#8221; to be &#8220;outside his working hours&#8221; or within working hours with the employer&#8217;s consent:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(5)</num>
+		  <intro>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In this section &#8216;appropriate time&#8217;, in relation to a worker taking part in any activities of a trade union, means time which either -</span></p>
+		  </intro>
+		  <subparagraph>
+		    <num style="font-family:'Times New Roman';font-size:13pt">(a)</num>
+		    <content>
+		      <p class="ParaLevel3" style="margin-left:2in;text-indent:0.5in"><span style="font-family:'Times New Roman'">is outside his working hours, or</span></p>
+		    </content>
+		  </subparagraph>
+		  <subparagraph>
+		    <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+		    <content>
+		      <p class="Quote" style="margin-left:2in;text-indent:0.5in"><span style="font-family:'Times New Roman'">is a time within his working hours at which, in accordance with arrangements agreed with, or consent given by or on behalf of, his employer, it is permissible for him to take part in those activities;</span></p>
+		    </content>
+		  </subparagraph>
+		  <wrapUp>
+		    <p class="Quote" style="margin-left:1in"><span style="font-family:'Times New Roman'">and in this subsection &#8216;working hours&#8217;, in relation to a worker, means any time when, in accordance with his contract with his employer, he is required to be at work.&#8221;</span></p>
+		  </wrapUp>
+		</paragraph>
+	      </embeddedStructure></block>
+	    <p class="ParaNoNumber"><span style="font-family:'Times New Roman'">As a matter of logic, this excluded strike action, for the reasons I have given.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_52">
+	  <num style="font-family:'Times New Roman';font-size:13pt">52.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'"><ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">The 1971 Act</ref> also introduced the statutory right not to be unfairly dismissed in sections 22 to 32. Section 24(4) deemed dismissals to be unfair if the reason was based on exercise of the rights conferred by <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72/section/5" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 5</ref>. Since <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72/section/5" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 5</ref> did not provide protection for strikers, section 24(4) could not and did not provide such protection either. Section 26 introduced a specific, more limited protection against dismissal for taking part in strike action, only where some strikers were not dismissed and the reason that the claimant was dismissed was the exercise or intention to exercise a right protected by <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72/section/5/1" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 5(1)</ref>. However, again, since <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72/section/5/1" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 5(1)</ref> did not protect the right to strike, section 26 confirmed that it was fair to dismiss an employee for taking part in a strike, but reinforced section 24(4) that it was not fair to dismiss a striker for trade union activities other than striking. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_53">
+	  <num style="font-family:'Times New Roman';font-size:13pt">53.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'"><ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">The 1971 Act</ref> was repealed by the <ref href="http://www.legislation.gov.uk/id/ukpga/1974/52" uk:canonical="1974 c. 52" uk:origin="TNA" uk:type="legislation">Trade Union and Labour Relations Act 1974</ref> (&#8220;<ref href="http://www.legislation.gov.uk/id/ukpga/1974/52" uk:canonical="1974 c. 52" uk:origin="TNA" uk:type="legislation">the 1974 Act</ref>&#8221;) which re-enacted the unfair dismissal protections. As before, it provided protection against selective dismissal of strikers based on their other union activities (Schedule 1 paragraph 8) or otherwise, but only for action outside working hours, or within working hours with the employer&#8217;s consent. The term &#8220;appropriate time&#8221; was used. Thus, Schedule 1 paragraph 6 provided:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(4)</num>
+		  <intro>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">For the purposes of this Schedule the dismissal of an employee by an employer shall be regarded as having been unfair if the reason for it (or, if more than one, the principal reason) was that the employee &#8230;</span></p>
+		  </intro>
+		  <subparagraph>
+		    <num style="font-family:'Times New Roman';font-size:13pt">(b)</num>
+		    <content>
+		      <p class="Quote" style="margin-left:1.5in;text-indent:0.5in"><span style="font-family:'Times New Roman'">had taken, or proposed to take, part at any appropriate time in the activities of an independent trade union; &#8230;&#8221;</span></p>
+		    </content>
+		  </subparagraph>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_54">
+	  <num style="font-family:'Times New Roman';font-size:13pt">54.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The <ref href="http://www.legislation.gov.uk/id/ukpga/1975/71" uk:canonical="1975 c. 71" uk:origin="TNA" uk:type="legislation">Employment Protection Act 1975</ref> (&#8220;<ref href="http://www.legislation.gov.uk/id/ukpga/1975/71" uk:canonical="1975 c. 71" uk:origin="TNA" uk:type="legislation">the 1975 Act</ref>&#8221;) reintroduced the protection against action short of dismissal in respect of trade union activities that had been available under <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">the 1971 Act</ref>. Again, protection was limited to employees who took part in the activities of specified unions &#8220;at any appropriate time&#8221; and &#8220;appropriate time&#8221; was defined as meaning &#8220;outside his working hours&#8221; or at a time within working hours with the employer&#8217;s consent: see section 53(2).</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_55">
+	  <num style="font-family:'Times New Roman';font-size:13pt">55.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Employment <ref href="http://www.legislation.gov.uk/id/ukpga/1978/44" uk:canonical="1978 c. 44" uk:origin="TNA" uk:type="legislation">Protection Consolidation Act 1978</ref> (&#8220;the EPCA&#8221;) consolidated the unfair dismissal protection in <ref href="http://www.legislation.gov.uk/id/ukpga/1974/52" uk:canonical="1974 c. 52" uk:origin="TNA" uk:type="legislation">the 1974 Act</ref> and the protection against action short of dismissal in <ref href="http://www.legislation.gov.uk/id/ukpga/1975/71" uk:canonical="1975 c. 71" uk:origin="TNA" uk:type="legislation">the 1975 Act</ref>, reuniting them in a single Act. <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/23" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 23</ref> of the EPCA replicated <ref href="http://www.legislation.gov.uk/id/ukpga/1975/71/section/53" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 53</ref> of <ref href="http://www.legislation.gov.uk/id/ukpga/1975/71" uk:canonical="1975 c. 71" uk:origin="TNA" uk:type="legislation">the 1975 Act</ref>, protecting employees against action short of dismissal for activities at any appropriate time. Part V of the EPCA enacted the protections against unfair dismissal, with <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/58" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 58</ref> re-enacting the protection in schedule 1 paragraph 6 of <ref href="http://www.legislation.gov.uk/id/ukpga/1974/52" uk:canonical="1974 c. 52" uk:origin="TNA" uk:type="legislation">the 1974 Act</ref> against dismissal for trade union activities at an appropriate time; and <ref href="http://www.legislation.gov.uk/id/ukpga/1990/38/section/62" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 62</ref> was the successor to <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72/section/26" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 26</ref> of <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">the 1971 Act</ref> and schedule 1 paragraph 8 of <ref href="http://www.legislation.gov.uk/id/ukpga/1974/52" uk:canonical="1974 c. 52" uk:origin="TNA" uk:type="legislation">the 1974 Act</ref>, addressing selective dismissals in a group of strikers. The effect of the Part V protections was the same, though they were achieved in a different way, by introducing a jurisdictional bar preventing tribunals from determining whether the dismissals of a group of strikers were fair or unfair, unless only a subset of the group had been dismissed. (<ref href="http://www.legislation.gov.uk/id/ukpga/1990/38/section/9" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 9</ref> of the <ref href="http://www.legislation.gov.uk/id/ukpga/1990/38" uk:canonical="1990 c. 38" uk:origin="TNA" uk:type="legislation">Employment Act 1990</ref> amended the EPCA to add <ref href="http://www.legislation.gov.uk/id/ukpga/1990/38/section/62" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 62</ref>A. This limited protection against dismissal for strikers further by providing that an employee could not &#8220;complain of unfair dismissal if at the time of dismissal he was taking part in an unofficial strike or other unofficial industrial action&#8221;: subsection (1)).</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_56">
+	  <num style="font-family:'Times New Roman';font-size:13pt">56.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">TULRCA consolidated the EPCA with other statutes. The protection against action short of dismissal in <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/23" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 23</ref> of the EPCA was re-enacted as <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA. The protection against dismissal in <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/58" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 58</ref> of the EPCA was re-enacted as <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> of TULRCA. Both protections again adopted the limitation that trade union activities were only protected if they took place &#8220;at an appropriate time&#8221;, derived originally from the ILO Convention and <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">the 1971 Act</ref>. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_57">
+	  <num style="font-family:'Times New Roman';font-size:13pt">57.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">TULRCA was amended to add <ref href="http://www.legislation.gov.uk/id/ukpga/1999/26/section/238" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 238</ref>A by the <ref href="http://www.legislation.gov.uk/id/ukpga/1999/26" uk:canonical="1999 c. 26" uk:origin="TNA" uk:type="legislation">Employment Relations Act 1999</ref> (<ref href="http://www.legislation.gov.uk/id/ukpga/1999/26/section/16" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 16</ref> and Schedule 5). This is the first provision to provide protection against dismissal on grounds of &#8220;protected industrial action&#8221; (in other words, lawful strike action) but it neither replaced nor amended the protections already applicable to activities at an appropriate time, which remained those available in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">sections 146</ref> and 152. Finally, <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA was amended by the <ref href="http://www.legislation.gov.uk/id/ukpga/2004/24" uk:canonical="2004 c. 24" uk:origin="TNA" uk:type="legislation">Employment Relations Act 2004</ref> (<ref href="http://www.legislation.gov.uk/id/ukpga/2004/24/section/30" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 30</ref>) to extend the protection available to workers as well as employees. No similar changes were made to the unfair dismissal regime in <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> of TULRCA, which remained restricted to employees.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_58">
+	  <num style="font-family:'Times New Roman';font-size:13pt">58.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Throughout, it is apparent that Parliament treated the protection that is now available under <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> as separate and distinct from the more limited protection that applied to those participating in lawful industrial action.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_59">
+	  <num style="font-family:'Times New Roman';font-size:13pt">59.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The legislative history demonstrates that the predecessor provisions (of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">sections 146</ref> and 152) in the 1974 and 1975 Acts had a shared source in <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">the 1971 Act</ref> (and before it the ILO Convention). The original statutory protections (in the 1974 and 1975 Acts) used the term &#8220;appropriate time&#8221; in the same way and precisely replicated the wording in <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">the 1971 Act</ref>. The only point at which <ref href="http://www.legislation.gov.uk/id/ukpga/1971/72" uk:canonical="1971 c. 72" uk:origin="TNA" uk:type="legislation">the 1971 Act</ref> protections against dismissal and action short of dismissal in respect of trade union activities were not both on the statute book was for a short period between 1974 and 1975, but once reunited in the EPCA, they have remained in the same statute. This legislative history also shows that Parliament has consistently chosen to provide protection for trade union activities at an appropriate time, whereas it has only ever given more limited and variable protection for striking employees.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_60">
+	  <num style="font-family:'Times New Roman';font-size:13pt">60.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">It is therefore necessary to consider whether the absence of any protection in TULRCA for employees and other workers taking part in lawful industrial action against measures short of dismissal is compatible with article 11, and, if not, whether the legislation can and should be read down to comply with article 11 or declared incompatible if reading down in this way is impossible. Before considering these questions, the starting point must be to consider what protection is required by article 11 in this context. </span></p>
+	  </content>
+	</paragraph>
+	<level eId="lvl_7">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">What protection does article 11 require for workers who take part in lawful industrial action?</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_61">
+	  <num style="font-family:'Times New Roman';font-size:13pt">61.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">It is common ground that article 11 (and indeed the ILO Convention) does not prevent an employer from withholding pay from a striking worker. That is unsurprising. At common law there is and can be no entitlement to pay where the worker performs no work. This is not a question of justifiable detrimental treatment as the Secretary of State submitted. Employers are recognised at common law (and by the ILO) as being within their rights to deduct pay from striking workers simply because there is no right to pay in circumstances where a worker is acting in breach of contract by withdrawing labour in this way. Such deductions are not sanctions and nor are they &#8220;detriments&#8221; at the domestic level.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_62">
+	  <num style="font-family:'Times New Roman';font-size:13pt">62.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">That apart, the appellant&#8217;s case is that all detriments (however slight) imposed by an employer in response to a worker participating in lawful industrial action, which deter or penalise a worker&#8217;s participation in lawful industrial action, are incompatible with article 11 and must be prohibited by the state even in the case of a private sector employer. (I note that it must follow from this submission, as a matter of logic, that any unprotected dismissal for participation in lawful strike action, in other words a dismissal for lawful strike action that does not attract the protections of TULRCA, would also be a breach of article 11. Mr Ford did not shrink from this result.) </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_63">
+	  <num style="font-family:'Times New Roman';font-size:13pt">63.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">As well as protecting the right to form and join a trade union, which is expressly protected as an instance of the right to freedom of association in article 11, article 11 has been held to safeguard a trade union&#8217;s freedom to protect the occupational interests of its members by collective action. In substance, this affords members of a trade union &#8220;the right for their union to be heard with a view to protecting their interests and requires national law to enable trade unions, in conditions not at variance with Article 11, to strive for the protection of their members&#8217; interests. However, it does not guarantee them any particular treatment by the State&#8221; (see </span><span style="font-style:italic;font-family:'Times New Roman'">Sindicatul &#8220;Pastorul cel Bun&#8221; v Romania</span><span style="font-family:'Times New Roman'"> <ref href="#" uk:canonical="(2013) 58 EHRR 10" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2013">(2013) 58 EHRR 10</ref>, (referred to below as the</span><span style="font-style:italic;font-family:'Times New Roman'"> &#8220;Good Shepherd</span><span style="font-family:'Times New Roman'">&#8221;) at para 134</span><span style="font-style:italic;font-family:'Times New Roman'">, Demir v Turkey <ref href="#" uk:canonical="(2008) 48 EHRR 54" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2008">(2008) 48 EHRR 54</ref>, </span><span style="font-family:'Times New Roman'">at para 141</span><span style="font-style:italic;font-family:'Times New Roman'">,</span><span style="font-family:'Times New Roman'"> and</span><span style="font-style:italic;font-family:'Times New Roman'"> Unite the Union v United Kingdom (2016) 63 EHRR SE7, </span><span style="font-family:'Times New Roman'">at para 53)</span><span style="font-style:italic;font-family:'Times New Roman'">. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_64">
+	  <num style="font-family:'Times New Roman';font-size:13pt">64.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Strasbourg jurisprudence makes clear that the right of association in the trade union context has several essential elements. These include the right to form and join a trade union, the prohibition of closed-shop agreements, the right for a trade union to seek to persuade the employer to hear what it has to say on behalf of its members and, in principle, the right to bargain collectively with the employer. This list is not finite as the court explained in </span><span style="font-style:italic;font-family:'Times New Roman'">Demir</span><span style="font-family:'Times New Roman'"> and is &#8220;subject to evolution depending on particular developments in labour relations&#8221;. This is because the Convention, as a living instrument, must be interpreted in line with present-day conditions, and in accordance with developments in international law, to &#8220;reflect the increasingly high standard being required in the area of the protection of human rights, thus necessitating greater firmness in assessing breaches of the fundamental values of democratic societies. In other words, limitations to rights must be construed restrictively, in a manner which gives practical and effective protection to human rights &#8230;&#8221; (see </span><span style="font-style:italic;font-family:'Times New Roman'">Demir</span><span style="font-family:'Times New Roman'"> at para 146).</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_65">
+	  <num style="font-family:'Times New Roman';font-size:13pt">65.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Where state interference or legislative restrictions strike at a core element of trade union activity, Strasbourg jurisprudence holds that a lesser margin of appreciation is afforded to the state, and more is required to establish proportionality. By contrast, if only a secondary aspect of trade union activity is affected, the margin is wider, and the interference is more likely to be proportionate as far as its consequences for the exercise of trade union freedom are concerned. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_66">
+	  <num style="font-family:'Times New Roman';font-size:13pt">66.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The question whether the right to strike, including taking secondary strike action, should properly be seen as core or essential elements of trade union freedom, was expressly considered by the Strasbourg court in the context of the UK&#8217;s ban on secondary strike action, in </span><span style="font-style:italic;font-family:'Times New Roman'">RMT.</span><span style="font-family:'Times New Roman'"> The applicant union argued that the right to strike had to be seen as an essential element of trade union freedom under article 11. In support of this argument reliance was placed (among other things) on a series of international treaties that were said to recognise the right to strike, or to have been authoritatively interpreted as protecting that right. For example, in the jurisprudence of the ILO supervisory bodies, the right to strike was seen as widely applied and strongly protected. There could be restrictions, but it was argued that these must not be such as to result, in practice, in an excessive limitation of the right to strike, such as a complete ban on secondary action.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_67">
+	  <num style="font-family:'Times New Roman';font-size:13pt">67.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Strasbourg court held in </span><span style="font-style:italic;font-family:'Times New Roman'">RMT</span><span style="font-family:'Times New Roman'"> (omitting case citations):</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;84.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The court will consider first the applicant&#8217;s argument that the right to take strike action must be regarded as an essential element of trade union freedom under article 11, so that to restrict it would be to impair the very essence of freedom of association. &#8230; More generally, what the above-mentioned cases [four cases against Turkey including </span><span style="font-style:italic;font-family:'Times New Roman'">Kara&#231;ay</span><span style="font-family:'Times New Roman'">] illustrate is that strike action is clearly protected by article 11. The court therefore does not discern any need in the present case to determine whether the taking of industrial action should now be accorded the status of an essential element of the article 11 guarantee.</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">85.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">What the circumstances of this case show is that the applicant in fact exercised two of the elements of freedom of association that have been identified as essential, namely the right for a trade union to seek to persuade the employer to hear what it has to say on behalf of its members, and the right to engage in collective bargaining. &#8230;</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">86.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In previous trade union cases, the court has stated that regard must be had to the fair balance to be struck between the competing interests of the individual and of the community as a whole. Since achieving a proper balance between the interests of labour and management involves sensitive social and political issues, the contracting states must be accorded a margin of appreciation as to how trade union freedom and protection of the occupational interests of union members may be secured. In its most recent restatement of this point, and referring to the high degree of divergence it observed between the domestic systems in this field, the Grand Chamber, considered that the margin should be a wide one (</span><span style="font-style:italic;font-family:'Times New Roman'">Sindicatul &#8220;Pastorul cel Bun</span><span style="font-family:'Times New Roman'">&#8221;, cited above, para 133). The applicant relied heavily on the </span><span style="font-style:italic;font-family:'Times New Roman'">Demir </span><span style="font-family:'Times New Roman'">judgment, in which the court considered that the respondent state should be allowed only a limited margin (see para 119 of the judgment). The court would point out, however, that the passage in question appears in the part of the judgment examining a very far-reaching interference with freedom of association, one that intruded into its inner core, namely the dissolution of a trade union. It is not to be understood as narrowing decisively and definitively the domestic authorities&#8217; margin of appreciation in relation to regulating, through normal democratic processes, the exercise of trade union freedom within the social and economic framework of the country concerned. The breadth of the margin will still depend on the factors that the court in its case law has identified as relevant, including the nature and extent of the restriction on the trade union right at issue, the object pursued by the contested restriction, and the competing rights and interests of other individuals in society who are liable to suffer as a result of the unrestricted exercise of that right. The degree of common ground between the member states of the Council of Europe in relation to the issue arising in the case may also be relevant, as may any international consensus reflected in the apposite international instruments (</span><span style="font-style:italic;font-family:'Times New Roman'">Demir</span><span style="font-family:'Times New Roman'">, para 85).</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">87.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">If a legislative restriction strikes at the core of trade union activity, a lesser margin of appreciation is to be recognised to the national legislature and more is required to justify the proportionality of the resultant interference, in the general interest, with the exercise of trade union freedom. Conversely, if it is not the core but a secondary or accessory aspect of trade union activity that is affected, the margin is wider and the interference is, by its nature, more likely to be proportionate as far as its consequences for the exercise of trade union freedom are concerned.</span></p>
+		  </content>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">88.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">As to the nature and extent of the interference suffered in the present case by the applicant in the exercise of its trade union freedom, the court considers that it was not as invasive as the applicant would have it. What the facts of the case reveal is that the applicant led a strike, albeit on a limited scale and with limited results . . . It cannot be said that the effect of the ban on secondary action struck at the very substance of the applicant&#8217;s freedom of association. &#8230;&#8221; </span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_68">
+	  <num style="font-family:'Times New Roman';font-size:13pt">68.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Thus, the Strasbourg court recognised expressly that strike action is clearly protected by article 11, but (at para 84) declined to determine &#8220;whether the taking of industrial action should now be accorded the status of an essential element of the article 11 guarantee.&#8221;</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_69">
+	  <num style="font-family:'Times New Roman';font-size:13pt">69.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Mr Ford submitted that there is a difference between what is core and what is essential in this context; and that participation in lawful strike action, while not essential, is the outward manifestation of, or a means of exercising, core trade union membership rights protected by article 11 and a core right. I disagree. It seems to me to be clear from the passages cited above that the court used &#8220;essential&#8221; and &#8220;core&#8221; interchangeably and declined to hold that strike action is core. Nor do I accept his submission that whether detrimental acts &#8220;strike at the core&#8221; of union rights depends not on which union rights are involved, but on whether the detrimental acts are targeted at individuals, so that individual sanctions on trade union members and officials strike directly at the core of article 11. This does not reflect the clear analysis of the Strasbourg court in </span><span style="font-style:italic;font-family:'Times New Roman'">RMT</span><span style="font-family:'Times New Roman'"> (and elsewhere), where no relevant distinction has been drawn between individual and collective sanctions. To the contrary, as the court made clear, making representations on behalf of a union falls squarely within the</span><span style="font-weight:bold;font-family:'Times New Roman'"/><span style="font-family:'Times New Roman'">conception of a core union activity, or, as the court put it in </span><span style="font-style:italic;font-family:'Times New Roman'">Straume v Latvia </span><span style="font-family:'Times New Roman'"><ref href="#" uk:canonical="[2022] IRLR 802" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2022">[2022] IRLR 802</ref></span><span style="font-style:italic;font-family:'Times New Roman'">,</span><span style="font-family:'Times New Roman'"> &#8220;advocating for the interests of trade union members is the very function of trade union representatives and constitutes a fundamental element of trade union freedom&#8221; (see para 102). </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_70">
+	  <num style="font-family:'Times New Roman';font-size:13pt">70.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Nonetheless, the Strasbourg court&#8217;s recognition of the right for a trade union to seek to persuade the employer to hear what it has to say on behalf of its members, and the right to engage in collective bargaining, underlines the importance of the right to strike as a means of defending these interests. As Mr Ford put it, the core right to advocate for the interests of trade union members is devoid of substance if it is not backed by a right to take strike action. That is certainly part of the reason why this right is protected. However, the Strasbourg court has not gone so far, in any case to which we were directed, as saying that it is a core right; and expressly declined to do so in </span><span style="font-style:italic;font-family:'Times New Roman'">RMT</span><span style="font-family:'Times New Roman'">. Indeed, as set out above, at para 86 in </span><span style="font-style:italic;font-family:'Times New Roman'">RMT</span><span style="font-family:'Times New Roman'">, the court re-emphasised the need for a fair balance to be struck between the competing interests of the individual and of the community, recognising that achieving a proper balance between the interests of labour and management involves sensitive social and political issues, and accordingly, the need for states to be afforded a margin of appreciation as to how trade union freedom and protection of the occupational interests of union members should be secured. It also recognised the high degree of divergence between the domestic systems in this field, leading to the conclusion that the margin was wide.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_71">
+	  <num style="font-family:'Times New Roman';font-size:13pt">71.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">By contrast, </span><span style="font-style:italic;font-family:'Times New Roman'">Demir</span><span style="font-family:'Times New Roman'"> and cases like it, where the state was allowed only a limited margin, involved what the Strasbourg court described as &#8220;a very far-reaching interference with freedom of association, one that intruded into its inner core, namely the dissolution of a trade union&#8230;&#8221;. Thus, the court held that a legislative restriction that strikes at a core element of trade union activity attracts a lesser margin of appreciation, and more is required to justify the proportionality of the resultant interference with the exercise of trade union freedom in the general interest. Conversely</span><span style="font-weight:bold;font-family:'Times New Roman'">, </span><span style="font-family:'Times New Roman'">if it is not the core but a secondary aspect of trade union activity that is affected, the margin is wider, and the interference is more likely to be proportionate as far as its consequences for the exercise of trade union freedom are concerned (see paras 86 and 87 of </span><span style="font-style:italic;font-family:'Times New Roman'">RMT</span><span style="font-family:'Times New Roman'">; and to similar effect </span><span style="font-style:italic;font-family:'Times New Roman'">Unite the Union v UK </span><span style="font-family:'Times New Roman'">at paras 55 and 66).</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_72">
+	  <num style="font-family:'Times New Roman';font-size:13pt">72.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The consequence of strike action not being a core or essential element of trade union freedoms (albeit protected) is that states are afforded a wide margin as to the limits that can be placed on the exercise of the right to strike. Legitimate restrictions can be imposed by the state, both substantive (in terms of what is or is not lawful) and procedural (for example, in terms of balloting and notification requirements). </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_73">
+	  <num style="font-family:'Times New Roman';font-size:13pt">73.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Nonetheless, the fact that the right to strike is protected is recognised in domestic law, for example, by the introduction of <ref href="http://www.legislation.gov.uk/id/ukpga/1999/26/section/238" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 238</ref>A of TULRCA. It is also illustrated by a series of Strasbourg cases relied on by the appellant. The following examples relied on by Mr Ford will suffice. In </span><span style="font-style:italic;font-family:'Times New Roman'">Ezelin,</span><span style="font-family:'Times New Roman'"> a reprimand issued to an advocate for participating in a demonstration against the judiciary (seen as tantamount to a strike) was held to be an infringement of article 11, notwithstanding the minor nature of the sanction. In&#160;</span><span style="font-style:italic;font-family:'Times New Roman'">Kara&#231;ay,</span><span style="font-family:'Times New Roman'"> a civil servant was alleged to have participated in a national one-day strike organised to protest declining salary levels and was issued with a warning. He complained that this sanction, intended to deter his activities as a trade union member, infringed his article 11 rights. The Strasbourg court examined this sanction to determine if it was proportionate to the legitimate purpose allegedly pursued, given what it described as &#8220;the prominent place of freedom of peaceful assembly&#8221;. Despite the sanction being minimal, it was intended to dissuade members of trade unions from legitimately taking part in a strike. It was not necessary in a democratic society and was an infringement of the right to freedom of assembly. (See also </span><span style="font-style:italic;font-family:'Times New Roman'">Kaya v Turkey</span><span style="font-family:'Times New Roman'"> to similar effect).</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_74">
+	  <num style="font-family:'Times New Roman';font-size:13pt">74.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In </span><span style="font-style:italic;font-family:'Times New Roman'">Ognevenko v Russia</span><span style="font-family:'Times New Roman'">, where a state-employed train driver participated in strike action notwithstanding a state ban on striking by railway workers and was dismissed, the Strasbourg court made clear that the right to strike was protected under article 11 as an important aspect of freedom of association and the right to form a trade union and for that trade union to be heard and to bargain collectively, but held that it was not absolute (para 58). While a complete ban on the right to strike, even in respect of certain key workers, would require &#8220;solid evidence&#8221; from the state to justify its necessity, the right to strike could be subject to restrictions under national law to limit or condition its exercise. In </span><span style="font-style:italic;font-family:'Times New Roman'">Ognevenko</span><span style="font-family:'Times New Roman'">, the state had not justified the blanket ban on strike action and the applicant&#8217;s dismissal was a disproportionate restriction on his right to freedom of association in circumstances where train drivers were not seen as providing an essential service (see paras 72 and 73). </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_75">
+	  <num style="font-family:'Times New Roman';font-size:13pt">75.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">As well as identifying a distinction between core rights and those that are secondary but remain protected, the Strasbourg court has also recognised a distinction between the state acting as public sector employer and penalising employees directly for participating in a strike (</span><span style="font-style:italic;font-family:'Times New Roman'">Ezelin</span><span style="font-family:'Times New Roman'">, </span><span style="font-style:italic;font-family:'Times New Roman'">Kara&#231;ay</span><span style="font-family:'Times New Roman'"> and </span><span style="font-style:italic;font-family:'Times New Roman'">Ognevenko </span><span style="font-family:'Times New Roman'">are examples and to the extent that a margin of appreciation was accorded to the state employer in question, it was a narrow margin); and cases where the state as regulator is said to owe a positive duty to legislate to protect privately employed workers&#8217; article 11 rights. Thus, for example, in </span><span style="font-style:italic;font-family:'Times New Roman'">RMT</span><span style="font-family:'Times New Roman'">, the Strasbourg court referred to cases like </span><span style="font-style:italic;font-family:'Times New Roman'">Kara&#231;ay </span><span style="font-family:'Times New Roman'">and held, at para 88:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<level>
+		  <content>
+		    <p class="Quote" style="margin-left:1in"><span style="font-family:'Times New Roman'">&#8220;On this ground the case is to be distinguished from those referred to in para 84 above, which all concerned restrictions on &#8216;primary&#8217; or direct industrial action by public sector employees; and the margin of appreciation to be recognised to the national</span><span style="font-family:'Times New Roman';color:#000000"/><span style="font-family:'Times New Roman'">authorities is the wider one available in relation to the regulation, in the public interest, of the secondary aspects of trade union activity.&#8221; </span></p>
+		  </content>
+		</level>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_76">
+	  <num style="font-family:'Times New Roman';font-size:13pt">76.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Mr Ford submitted that the distinction being drawn by the court was between primary and secondary aspects of trade union activity, and not state and private sector employers. Again, I disagree. As the Court of Appeal observed, and I agree, the Strasbourg court was being careful in its choice of language. Plainly if the state is the employer and the lawful industrial action is directed against the employer, even a minimal sanction is likely to involve a breach of article 11. However, where the action is secondary or the employer is in the private sector so that the state has a different role, the position is less clear. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_77">
+	  <num style="font-family:'Times New Roman';font-size:13pt">77.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Mr Ford relied on two cases relating to private employers in support of the proposition that article 11 operates to require protection for workers in the private sector participating in industrial action from any detriment. However, I do not consider that either case supports his proposition. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_78">
+	  <num style="font-family:'Times New Roman';font-size:13pt">78.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The first is </span><span style="font-style:italic;font-family:'Times New Roman'">Danilenkov v Russia,</span><span style="font-family:'Times New Roman'"> where there was a dispute as to whether the employer was a private or public sector entity, but the court found it unnecessary to resolve this dispute given its conclusion that the state had a positive duty, in any event, to secure the article 11 rights engaged. The case involved a wholesale attack on trade union membership to oust the union from the workforce. This was initially triggered by strike action and those who had participated were penalised in different ways, and eventually targeted for redundancy, because of their trade union membership. The union and its members brought civil proceedings seeking declarations that they had been discriminated against on grounds of union membership. The proceedings were dismissed by the domestic courts because such discrimination could only be established in criminal proceedings, but a relevant employing legal entity could not be held criminally liable. The applicants were therefore left without any effective legal remedy. As a result of the employer&#8217;s actions, union membership fell dramatically, and the small number who remained at the end of this &#8220;campaign&#8221; were mostly dismissed. The complaint in this case, accordingly, concerned egregious conduct amounting to a sustained attack on union membership, aimed at ousting the union altogether. The effect of the campaign was to all but eliminate union membership. Although industrial action triggered the campaign that followed, this was not the central feature of the case. Rather, the employer&#8217;s actions went to the heart (or core) of the protection afforded by article 11, namely the right to join and remain a member of a trade union. In upholding the complaint, the Strasbourg court held that there was a prima facie case of discrimination in the enjoyment of the rights guaranteed by article 11. There was no finding of any free-standing violation of article 11 whether by reference to core rights or the right to strike. Rather, the court held that the state had failed to fulfil its positive obligations to adopt effective judicial protection against discrimination on the ground of trade union membership. It followed that there had been a violation of article 14 read with article 11. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_79">
+	  <num style="font-family:'Times New Roman';font-size:13pt">79.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The second is </span><span style="font-style:italic;font-family:'Times New Roman'">Tek Gida I&#351; Sendikasi v Turkey </span><span style="font-family:'Times New Roman'">(Application No 35009/05) (unreported) 4 April 2017, ECtHR, where the union alleged that a large-scale wrongful dismissal of its members by their employer to ensure that the union did not attain the requisite membership threshold had resulted in the absolute eradication of trade unionism across the whole company in less than a year (para 48). The court concluded that, in failing to have in place suitable deterrents to the employer&#8217;s actions, the state had failed in its positive obligation to secure effective enjoyment of the union&#8217;s right to seek to persuade the employer to hear what it had to say on behalf of its members and engage in collective bargaining (para 51). This resulted in the de-unionisation of the entire workforce and was seen as striking at the core of the union&#8217;s activities (paras 54 and 55). A narrower margin applied, and more was required to justify the proportionality of the interference. This case too, was not concerned with the right to strike or the protection from detrimental treatment for workers participating in a lawful strike. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_80">
+	  <num style="font-family:'Times New Roman';font-size:13pt">80.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">These and other cases show that the Strasbourg court has recognised a difference between the protection afforded by article 11 to the individual against arbitrary interference by public authority employers with the exercise of rights protected by it, and the positive obligations on the state to secure the effective enjoyment of these rights. As the Strasbourg court has said, the boundaries between the state&#8217;s positive and negative obligations are not clearly defined, and the applicable principles may be similar in that, in both contexts, regard must be had to the fair balance to be struck between the competing interests involved. Nevertheless, it seems clear from the court&#8217;s jurisprudence that in the context of the state&#8217;s positive obligations as regulator, a wider enquiry, and a wider margin of appreciation, accordingly, is involved. Where the question concerns the extent of the state&#8217;s positive obligation to regulate the exercise of trade union freedom within the social and economic framework of the country concerned, &#8220;the social and political issues involved in achieving a proper balance between the interests of labour and management are of a sensitive nature&#8221;. Moreover, the Strasbourg court has recognised that national authorities, and democratically elected parliaments, are in principle better placed than it is to appreciate what is in the public interest on social or economic grounds and the legislative measures which are best suited for national conditions in order to implement the chosen social, economic or industrial policy (see for example, para 89 of </span><span style="font-style:italic;font-family:'Times New Roman'">RMT</span><span style="font-family:'Times New Roman'">). The starting point is, therefore, that &#8220;the United Kingdom enjoys a wide margin of appreciation in determining whether a fair balance has been struck between the protection of the public interest &#8230; and the applicant&#8217;s competing rights under Article 11&#8221; (see para 60 of </span><span style="font-style:italic;font-family:'Times New Roman'">Unite the Union v UK</span><span style="font-family:'Times New Roman'">). The breadth of the margin will, however, still depend on factors such as the nature and extent of the restriction on the trade union right at issue, the object pursued by the impugned restriction, and the wider competing rights of those liable to suffer because of the unrestricted exercise of that right. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_81">
+	  <num style="font-family:'Times New Roman';font-size:13pt">81.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Drawing the threads together, this review of the Strasbourg jurisprudence shows that, although the right to strike is protected by article 11, it is not a core right. Nor is the right to strike absolute. That is unsurprising. Strike action is liable to infringe the contractual rights of the employer, and in certain cases, the employer&#8217;s rights under article 1 of the First Protocol to the Convention. It may also interfere with the legal rights of third parties (suppliers, customers, members of the public). Given the competing considerations at stake, the protection afforded to striking workers and unions is also neither absolute nor unlimited. Moreover, in circumstances where under domestic law dismissal of an employee for participating in lawful industrial action is acknowledged to be justifiable in some circumstances, it would be irrational to conclude that article 11 requires that detrimental treatment short of dismissal of a worker for such participation can never be justified. Since protection against dismissal in <ref href="http://www.legislation.gov.uk/id/ukpga/1999/26/section/238" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 238</ref>A of TULRCA expires after the industrial action has been going for 12 weeks, it would be surprising if at that point the employer could dismiss employees taking lawful strike action with impunity but could not lawfully impose any lesser detriment on workers participating in a lawful strike.</span></p>
+	  </content>
+	</paragraph>
+	<level eId="lvl_8">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">What are the state&#8217;s obligations here?</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_82">
+	  <num style="font-family:'Times New Roman';font-size:13pt">82.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The present case concerns the state&#8217;s positive obligations as regulator of relationships between private employers and workers in relation to a right that is protected but is not a core right. The Strasbourg court has afforded states a wider margin of appreciation in this context given the &#8220;sensitive social and political issues&#8221; involved in achieving a proper balance between the competing interests of labour and management, the individual and the community. The cases relied on by the appellant (referred to at paras 73 to 75 above) illustrate how the margin of appreciation operates in the context of detrimental action against striking workers. Whereas the court has found violations by the state imposing detrimental action itself, it has never made a finding that the state is required to prohibit all detrimental action by private employers against striking workers. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_83">
+	  <num style="font-family:'Times New Roman';font-size:13pt">83.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In my judgment the state&#8217;s positive obligations under article 11 do not require it to confer universal protection in all circumstances to all workers against any detriment (however slight) intended to dissuade or penalise them from participating in a lawful strike. If that were the case, the conditions that must be fulfilled to attract the protection from dismissal afforded under Part V of TULRCA would be incompatible with the UK&#8217;s obligations under article 11, and </span><span style="font-style:italic;font-family:'Times New Roman'">RMT</span><span style="font-family:'Times New Roman'"> would have been decided differently. Equally, it would be surprising if sanctions could not be imposed in circumstances where an employer could permissibly dismiss an employee for participation in a lawful strike. There may be circumstances where it is permissible to impose a detriment for participating in lawful strike action where employees have necessarily acted in breach of contract, particularly where the manner of the breach is harmful or disruptive. However, it does not follow that in a private sector case where sanctions short of dismissal are imposed to deter lawful strike action, the state has no positive obligations at all. On the contrary, the legislative scheme must strike a fair balance between the competing interests at stake and any provision of the scheme that restricts the protection of article 11 rights must be justified, recognising the margin of appreciation to be accorded to the state.</span></p>
+	  </content>
+	</paragraph>
+	<level eId="lvl_9">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">Has a fair balance been struck?</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_84">
+	  <num style="font-family:'Times New Roman';font-size:13pt">84.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Mr Stilitz submitted that the legislative scheme, taken as a whole, is indeed justified: Parliament has provided finely calibrated (but limited) protections for employees against being dismissed for participating in industrial action, but has chosen not to go further and impose a ban on detrimental treatment short of dismissal on grounds of such action. He submitted that the legislative regime has taken a carefully considered approach to regulating employers&#8217; conduct and that the balance struck by <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA, read in the context of the other statutory provisions and protections applying in this context, is necessary in a democratic society and proportionate: see </span><span style="font-style:italic;font-family:'Times New Roman'">Bank Mellat v HM Treasury (No 2) </span><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/uksc/2013/39" uk:canonical="[2013] UKSC 39" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2013">[2013] UKSC 39</ref>, <ref href="#" uk:canonical="[2014] AC 700" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2014">[2014] AC 700</ref> (per Lord Sumption at para 20). In support of his submission that it plainly fell within the UK&#8217;s margin of discretion to permit employers to discipline or penalise strikers, Mr Stilitz relied on what were suggested to be other protections given to those who take industrial action in domestic law, such as the Acas Code of Practice on Disciplinary and Grievance Procedures, the implied term of trust and confidence in employment contracts, the absence of criminal sanctions for strikes, and other protections in TULRCA and in the <ref href="http://www.legislation.gov.uk/id/ukpga/1999/26" uk:canonical="1999 c. 26" uk:origin="TNA" uk:type="legislation">Employment Relations Act 1999</ref> (Blacklist) Regulations 2010 (SI 2010/493), the &#8220;Blacklisting Regulations&#8221;. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_85">
+	  <num style="font-family:'Times New Roman';font-size:13pt">85.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">I accept that the totality of available protections must be considered as Mr Stilitz submitted. I also recognise that it is likely that deliberate choices have been made by Parliament in legislating as it has (although I cannot confidently rule out the possibility of legislative oversight in relation to the breadth of the exclusion from protection against detriment for participation in lawful industrial action in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> of TULRCA in the absence of any material to indicate that this point has been positively considered). Despite these considerations, I do not accept the Secretary of State&#8217;s submission that the absence of any protection is justified. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_86">
+	  <num style="font-family:'Times New Roman';font-size:13pt">86.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">First, I am far from persuaded that the avenues identified by Mr Stilitz provide any real or effective protection in the case of a striking worker faced with a disciplinary sanction for taking part in a lawful strike. The Acas Code does not give rise to independent legal rights that protect the worker beyond ensuring that the employer&#8217;s disciplinary or grievance process accords with the principles of natural justice and is reasonable and fair. As Mr Ford submitted, the implied term of trust and confidence has never provided a remedy in this context, no doubt because at common law a striking worker is in repudiatory breach of contract and/or because the employer would have reasonable cause for its action. The Blacklisting Regulations only apply where an employer creates a &#8220;prohibited list&#8221;, as defined in regulation 3, and not in other circumstances. Moreover, Mr Stilitz provided no example of a case where domestic law (other than <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref>) might protect an individual striker from sanctions short of dismissal for taking part in a lawful strike. In practice, the protection relied on adds very little in context. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_87">
+	  <num style="font-family:'Times New Roman';font-size:13pt">87.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Secondly, although TULRCA protects the interests of trade unions and their members in certain ways, it provides no protection whatever for detrimental treatment short of dismissal of those taking lawful industrial action, and no such protection is available anywhere else in domestic law. As the Court of Appeal observed, and I agree, it is not difficult to envisage cases where domestic law provides no or limited protection against sanctions on employees taking lawful industrial action which might well amount to a breach of article 11. For example, if an employer sued strikers for loss of profits caused by their breach of contract in going on strike (see </span><span style="font-style:italic;font-family:'Times New Roman'">National Coal Board v Galley</span><span style="font-family:'Times New Roman'"> <ref href="#" uk:canonical="[1958] 1 WLR 16" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="1958">[1958] 1 WLR 16</ref>). Another example, at least arguably, would be if striking workers returning to work were suspended without pay as a disciplinary measure. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_88">
+	  <num style="font-family:'Times New Roman';font-size:13pt">88.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In these circumstances, the Court of Appeal held:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;71.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">We conclude that the failure to give legislative protection against any sanction short of dismissal for official industrial action against the employees who take it may put the United Kingdom in breach of article 11 even in the case of a private sector employer, if the sanction is one which strikes at the core of trade union activity. We emphasise, however, that this is an issue which is divorced from the underlying facts of this case. There have been no findings of fact including with respect to the employer&#8217;s motives in acting as it did, nor about the reasonableness or proportionality of its actions.&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_89">
+	  <num style="font-family:'Times New Roman';font-size:13pt">89.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Even accepting as I do that there may be a wider margin of appreciation to be accorded to the legislature in this case, the margin of appreciation is never unlimited. Moreover, in my judgment the right of an employer to impose any sanction at all short of dismissal for participation in lawful industrial action nullifies the right to take lawful strike action. If employees can only take strike action by exposing themselves to detrimental treatment, the right dissolves. Nor is it clear what legitimate aim a complete absence of such protection serves. In the context of the scheme of protection that is available, it is hard to see what pressing social need is served by a general rule that has the effect of excluding protection from sanctions short of dismissal for taking lawful strike action in all circumstances. Seen in this way, <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA both encourages and legitimises unfair and unreasonable conduct by employers. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_90">
+	  <num style="font-family:'Times New Roman';font-size:13pt">90.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Had there been legislation addressing action short of dismissal, it might have been possible to say that a fair balance had been struck by Parliament given the wider margin of appreciation to be applied. However, I consider that the failure to provide any legislative protection at all against any sanction short of dismissal for lawful industrial action against those who take it, does put the United Kingdom in breach of its positive obligation to secure effective enjoyment of the right to participate in a lawful strike that is protected by article 11 (including as regards the private sector). Indeed, I find it difficult to see how a balance has been struck at all. Like the Court of Appeal, I make clear that this is an issue which is divorced from the underlying facts of this case and there have, as yet, been no findings of fact about AFG&#8217;s intention in acting as it did, nor about the reasonableness or proportionality of its actions.</span></p>
+	  </content>
+	</paragraph>
+	<level eId="lvl_10">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">Is it possible for <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> to be interpreted in a Convention-compliant way?</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_91">
+	  <num style="font-family:'Times New Roman';font-size:13pt">91.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Having concluded that the absence of any protection in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA for detriment short of dismissal for participation in lawful strike action is incompatible with article 11, the next question to be addressed is whether the Court of Appeal erred in its approach to <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA and whether it should have held that a compliant construction of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA was possible within the meaning of <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_92">
+	  <num style="font-family:'Times New Roman';font-size:13pt">92.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'"><ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 3</ref> requires that, so far as it is possible to do so, primary legislation must be read and given effect in a way which is compatible with rights guaranteed under the Convention. In other words, the courts are required to interpret primary legislation to comply with Convention rights unless the legislation itself makes it impossible to do so. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_93">
+	  <num style="font-family:'Times New Roman';font-size:13pt">93.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The approach to <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> is well established and not controversial on this appeal. As it was described by Lord Reed (with whom Lords Hodge, Lloyd-Jones, Sales and Stephens agreed) in </span><span style="font-style:italic;font-family:'Times New Roman'">In re United Nations Convention on the Rights of the Child (Incorporation) (Scotland) Bill </span><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/uksc/2021/42" uk:canonical="[2021] UKSC 42" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2021">[2021] UKSC 42</ref>, <ref href="#" uk:canonical="[2021] 1 WLR 5106" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2021">[2021] 1 WLR 5106</ref> at paras 25 and 26:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;25.</num>
+		  <intro>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'"><ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 3</ref> of the Human Rights Act was interpreted in </span><span style="font-style:italic;font-family:'Times New Roman'">Ghaidan v Godin-Mendoza </span><span style="font-family:'Times New Roman'">as imposing a remarkably powerful interpretative obligation, which goes well beyond the normal canons of statutory construction. The nature of the obligation was explained by Lord Nicholls of Birkenhead at para 30:</span></p>
+		  </intro>
+		  <subparagraph>
+		    <content>
+		      <p class="Quote" style="margin-left:1.5in"><span style="font-family:'Times New Roman'">&#8216;the interpretative obligation decreed by <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> is of an unusual and far-reaching character. <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 3</ref> may require a court to depart from the unambiguous meaning the legislation would otherwise bear. In the ordinary course the interpretation of legislation involves seeking the intention reasonably to be attributed to Parliament in using the language in question. <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 3</ref> may require the court to depart from this legislative intention, that is, depart from the intention of the Parliament which enacted the legislation.&#8217;</span></p>
+		    </content>
+		  </subparagraph>
+		</paragraph>
+		<paragraph>
+		  <intro>
+		    <p class="Quote" style="margin-left:1in"><span style="font-family:'Times New Roman'">Lord Nicholls added at para 32:</span></p>
+		  </intro>
+		  <subparagraph>
+		    <content>
+		      <p class="Quote" style="margin-left:1.5in"><span style="font-family:'Times New Roman'">&#8216;the mere fact the language under consideration is inconsistent with a Convention-compliant meaning does not of itself make a Convention-compliant interpretation under <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> impossible. <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">Section 3</ref> enables language to be interpreted restrictively or expansively. But <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> goes further than this. It is also apt to require a court to read in words which change the meaning of the enacted legislation, so as to make it Convention-compliant. In other words, the intention of Parliament in enacting <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> was that, to an extent bounded only by what is &#8220;possible&#8221;, a court can modify the meaning, and hence the effect, of primary and secondary legislation.&#8217;</span></p>
+		    </content>
+		  </subparagraph>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">26.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The House of Lords accordingly held that <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> required, where necessary, that the courts, and other public authorities, should give to provisions in statutes, including statutes enacted subsequent to the Human Rights Act, a meaning and effect that conflicted with the legislative intention of the Parliaments enacting those statutes. &#8230;&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_94">
+	  <num style="font-family:'Times New Roman';font-size:13pt">94.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Nonetheless, there are limits to its use and not all provisions in primary legislation can be rendered Convention-compliant by the application of <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3/1" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3(1)</ref> of the HRA. While this section gives the court a powerful tool with which to interpret legislation, it does not enable the court to change the substance of a provision from one where it says one thing into one that says the opposite; or as Lord Nicholls explained at para 33 in </span><span style="font-style:italic;font-family:'Times New Roman'">Ghaidan v Godin-Mendoza</span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman'"/><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2004/30" uk:canonical="[2004] UKHL 30" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2004">[2004] UKHL 30</ref>, <ref href="#" uk:canonical="[2004] 2 AC 557" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2004">[2004] 2 AC 557</ref>, to &#8220;adopt a meaning inconsistent with a fundamental feature of legislation&#8221;. Further, as Lord Rodger observed at para 115, &#8220;difficult questions may also arise where, even if the proposed interpretation does not run counter to any underlying principle of the legislation, it would involve reading into the statute powers or duties with far-reaching practical repercussions&#8221;. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_95">
+	  <num style="font-family:'Times New Roman';font-size:13pt">95.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In </span><span style="font-style:italic;font-family:'Times New Roman'">Sheldrake v Director of Public Prosecutions </span><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2004/43" uk:canonical="[2004] UKHL 43" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2004">[2004] UKHL 43</ref>, <ref href="#" uk:canonical="[2005] 1 AC 264" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2005">[2005] 1 AC 264</ref>, at para 28, Lord Bingham referred to the cases of </span><span style="font-style:italic;font-family:'Times New Roman'">R </span><span style="font-family:'Times New Roman'">(</span><span style="font-style:italic;font-family:'Times New Roman'">Anderson</span><span style="font-family:'Times New Roman'">) </span><span style="font-style:italic;font-family:'Times New Roman'">v Secretary of State for the Home Department </span><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2002/46" uk:canonical="[2002] UKHL 46" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] UKHL 46</ref>, <ref href="#" uk:canonical="[2003] 1 AC 837" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2003">[2003] 1 AC 837</ref> and </span><span style="font-style:italic;font-family:'Times New Roman'">Bellinger v Bellinger </span><span style="font-family:'Times New Roman'">as illustrating the limit beyond which a Convention-compliant interpretation is not possible and said:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<level>
+		  <content>
+		    <p class="Quote" style="margin-left:1in"><span style="font-family:'Times New Roman'">&#8220;In explaining why a Convention-compliant interpretation may not be possible, members of the committee used differing expressions: such an interpretation would be incompatible with the underlying thrust of the legislation, or would not go with the grain of it, or would call for legislative deliberation, or would change the substance of a provision completely, or would remove its pith and substance, or would violate a cardinal principle of the legislation (paras 33, 49, 110&#8211;113, 116). All of these expressions, as I respectfully think, yield valuable insights, but none of them should be allowed to supplant the simple test enacted in <ref href="http://www.legislation.gov.uk/id/ukpga/1999/26" uk:canonical="1999 c. 26" uk:origin="TNA" uk:type="legislation">the Act</ref>: &#8216;So far as it is possible to do so &#8230;&#8217;. While the House declined to try to formulate precise rules (para 50), it was thought that cases in which <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> could not be used would in practice be fairly easy to identify.&#8221;</span></p>
+		  </content>
+		</level>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_96">
+	  <num style="font-family:'Times New Roman';font-size:13pt">96.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Applying these principles, the Court of Appeal in this case held that a substantial obstacle in the appellant&#8217;s way to a Convention-compliant interpretation of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> TULRCA is that there is more than one possible solution to the problem. The appellant had accepted that only lawful (as opposed to all) industrial action should be protected, but the Court of Appeal raised the question whether the protection against detriment short of dismissal should extend, for example, to long-running lawful industrial action (given that the protection against dismissal in <ref href="http://www.legislation.gov.uk/id/ukpga/1999/26/section/238" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 238</ref>A expires after the industrial action has been going on for 12 weeks). The Court of Appeal made the further observation that &#8220;it is far from obvious that article 11 requires protection to be given against every form of detriment, at any rate in a private sector case, in response to industrial action. For example, does it require the law of each state to provide that the employer will be acting unlawfully if the employees concerned were refused a discretionary bonus; or were not considered the next time that a vacancy occurred for an internal promotion? The Strasbourg case law cited to us does not give a clear answer to those questions.&#8221; (See para 76). </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_97">
+	  <num style="font-family:'Times New Roman';font-size:13pt">97.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Court of Appeal concluded that these were issues of policy in a highly sensitive area that are best left to Parliament and continued:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;81.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The effect of the attempt to interpret <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> by adding an additional sub-clause (whether as originally drafted or now refined by Mr Ford) would result in impermissible judicial legislation and not interpretation as sanctioned by <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42" uk:canonical="1998 c. 42" uk:origin="TNA" uk:type="legislation">the 1998 Act</ref>. The employment judge was correct to decline to do so.&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_98">
+	  <num style="font-family:'Times New Roman';font-size:13pt">98.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Mr Ford challenges this conclusion. He submitted that, as conventionally interpreted, <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> places two barriers in the way of an article 11-compliant construction: the fact that the parallel protections on unfair dismissal for trade union activities in <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> exclude participation in industrial action and the definition of an &#8220;appropriate time&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref>, as meaning a time outside working hours or a time within working hours with the employer&#8217;s consent (which will exclude most, but not all, industrial action). He submitted however, that these barriers can be surmounted because the general thrust of the legislation (see the provisions in Part V) is that lawful industrial action is a legitimate trade union activity, and the specific thrust of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> was, and is, to protect freedom of association (with its genesis in the ILO Convention) by protecting the right to form and join unions and take part in trade union activities. The thrust of the legislation across time has always been to comply with article 11 as demonstrated by amendments made to TULRCA by Part 3 of the <ref href="http://www.legislation.gov.uk/id/ukpga/2004/24" uk:canonical="2004 c. 24" uk:origin="TNA" uk:type="legislation">Employment Relations Act 2004</ref>, introducing <ref href="http://www.legislation.gov.uk/id/ukpga/2004/24/section/145" uk:canonical="" uk:origin="TNA" uk:type="legislation">sections 145</ref>A to F to bring domestic law into line with the decision of the Strasbourg court in </span><span style="font-style:italic;font-family:'Times New Roman'">Wilson v United Kingdom </span><span style="font-family:'Times New Roman'"><ref href="#" uk:canonical="(2002) 35 EHRR 20" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2002">(2002) 35 EHRR 20</ref>, <ref href="#" uk:canonical="[2002] IRLR 568" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] IRLR 568</ref></span><span style="font-style:italic;font-family:'Times New Roman'">.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_99">
+	  <num style="font-family:'Times New Roman';font-size:13pt">99.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Nor, he submitted, are the distinct rules applying to unfair dismissal a bar to a compliant construction of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> to protect union members against action short of dismissal. These are distinct regimes, and the words &#8220;at an appropriate time&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> can legitimately be interpreted differently from <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref>, given that article 11 rights are involved in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref>, but not engaged in <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref>: see </span><span style="font-style:italic;font-family:'Times New Roman'">R (Hurst) v London Northern District Coroner </span><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2007/13" uk:canonical="[2007] UKHL 13" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2007">[2007] UKHL 13</ref>, <ref href="#" uk:canonical="[2007] 2 AC 189" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2007">[2007] 2 AC 189</ref>, per Lord Rodger at paras 12 to 13 and Lord Brown at para 52. As for the definition of an &#8220;appropriate time&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref>, he relied on the description at para 83 of the EAT&#8217;s judgment of it as an &#8220;imprecise and highly permeable barrier&#8221; between included or excluded industrial action and submitted that given the general scheme, purpose and thrust of the legislation to protect freedom of association, and comply with article 11 and the ILO Convention, it is a barrier which can be surmounted under <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_100">
+	  <num style="font-family:'Times New Roman';font-size:13pt">100.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Furthermore, Mr Ford submitted that the Court of Appeal did not reject a compliant construction because it was contrary to the grain of the legislation. Rather, it relied on the fact that policy questions were involved and there was more than one possible solution to the problem. But, he submitted, given the clear, consistent jurisprudence of the Strasbourg court and the domestic &#8220;mirror&#8221; principle, (namely, the duty of national courts generally to keep pace with the Strasbourg jurisprudence, doing no more than this, but certainly no less: see </span><span style="font-style:italic;font-family:'Times New Roman'">R (Ullah) v Special Adjudicator</span><span style="font-family:'Times New Roman'"> cited above, at para 20, per Lord Bingham) the potential policy questions raised by the Court of Appeal do not arise. Parliament has already addressed the social and economic policy issues raised in defining what is lawful industrial action in the UK, and article 11 clearly requires UK law to provide real and effective protection against sanctions, however minimal, intended to dissuade union members from taking part in lawful industrial action or to penalise them for doing so. It is obvious that there is no time limit on that protection. As to the question whether article 11 requires protection against every sort of detriment in a private sector case, his answer was that just as the cases on article 11 focus on whether a sanction was intended to dissuade participation in trade union activities, so too the guiding principle of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> is whether the &#8220;sole or main purpose&#8221; of the employer&#8217;s action was to prevent, deter or penalise participation in trade union activities. The factual questions which arise here are no different from those which arise under <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> in the context of &#8220;ordinary&#8221; trade union activities or in applying the many other statutory provisions which protect a worker from being subjected to a detriment for certain proscribed reasons, including in some cases unpaid absences from work (for example in sections 43M (absence on jury service), 45 (refusal to work Sundays), 47C (family or domestic leave) of the <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18" uk:canonical="1996 c. 18" uk:origin="TNA" uk:type="legislation">Employment Rights Act 1996</ref>)). </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_101">
+	  <num style="font-family:'Times New Roman';font-size:13pt">101.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Mr Ford submitted in conclusion that the only linguistic barrier to a compliant interpretation is the definition of &#8220;appropriate time&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> of TULRCA. Although the appellant is not required to provide a solution, the appellant&#8217;s suggested solution is to read a new sub-paragraph (c) into the definition of an &#8220;appropriate time&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref>:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;(c)</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">in respect of a detriment short of dismissal, a time within working hours when he is taking part in protected industrial action within the meaning of <ref href="http://www.legislation.gov.uk/id/ukpga/1999/26/section/238" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 238</ref>A(1).&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	    <p class="ParaNoNumberApproved"><span style="font-family:'Times New Roman'">This would have the effect that workers will only be protected where the industrial action is called by the union and so constitutes a &#8220;trade union activity&#8221;; they are subject to a detriment, short of dismissal, for the proscribed purposes in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/1" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(1)</ref>, mirroring the protection of article 11; and the action is lawful in accordance with the detailed rules in Part V of TULRCA, meaning the strike must be primary industrial action, taken in contemplation or furtherance of a trade dispute, and compliant with the rules on balloting, notification and the like.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_102">
+	  <num style="font-family:'Times New Roman';font-size:13pt">102.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Persuasively as these submissions were advanced, I do not accept them. In my judgment, the Court of Appeal was correct to hold that a Convention compatible interpretation of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA is not possible and would amount to impermissible judicial legislation rather than interpretation. I recognise that <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA can require a court to read in words which change the meaning and the effect of the legislation to achieve a compatible interpretation. However, I do not consider that there is a single, obvious legislative solution that will ensure compliance with article 11 while at the same time maintaining an appropriate balance between the competing rights of employers and their workers in this politically and socially sensitive context. Moreover, to interpret <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> in the way proposed by the appellant would contradict a fundamental feature of the legislation. My reasons for these conclusions follow. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_103">
+	  <num style="font-family:'Times New Roman';font-size:13pt">103.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">First, although article 11 may well require some protection (as opposed to none) for detriment short of dismissal in this context, I have rejected the argument advanced by the appellant that universal protection from all detriments is inevitably required by article 11. Having reached that conclusion, it is far from obvious to me what the nature, scope and structure of the requisite protection should be. As I have said, I cannot rule out the possibility that, consistently with the UK&#8217;s positive obligations under article 11, there might be some circumstances where it would be permissible for a private employer to impose a sanction of some kind for participation in lawful industrial action (which may take many forms). I cannot assume that Parliament would necessarily choose to legislate to prohibit all forms of detriment, including, for example, reduction of a discretionary bonus or removal of a non-contractual benefit, irrespective of the application of the &#8220;sole or main purpose&#8221; test.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_104">
+	  <num style="font-family:'Times New Roman';font-size:13pt">104.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">There are other policy choices that will have to be made if Parliament decides that legislative protection is required. The formulation currently proposed by the appellant would permit an employer to dismiss a &#8220;limb (b) worker&#8221; (that is to say, a worker who is not an employee but who nonetheless enjoys protection within the wider definition of &#8220;worker&#8221;, including those engaged under contracts to perform work personally) for participating in lawful industrial action (there being no other prohibition on dismissing workers as opposed to employees); and would prohibit an employer from subjecting an employee to any detriment short of dismissal in circumstances where the employer would be lawfully permitted to dismiss that employee under <ref href="http://www.legislation.gov.uk/id/ukpga/1999/26/section/238" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 238</ref>A of TULRCA. It follows that the introduction of legislation in this area would necessarily require consideration of whether the protection in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> should mirror (or should be more or less protective than) the complex but limited protection against dismissal on grounds of taking industrial action contained in sections 237 to 238A of TULRCA, thus permitting detrimental action short of dismissal in certain circumstances. Related to this, and depending on the formulation adopted, there may have to be consideration of whether limb (b) workers should enjoy greater protection for detriment by way of dismissal for lawful participation in a strike. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_105">
+	  <num style="font-family:'Times New Roman';font-size:13pt">105.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">For this reason, seeking to interpret <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> using <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA in this way, is tantamount to judicial legislation. It fundamentally alters the scope and structure of the rights conferred by TULRCA, re-drawing the balance between workers&#8217; and employers&#8217; rights. There is no formulation that does not involve making a series of policy choices that may have far-reaching practical ramifications. This goes beyond the permissible boundary of interpretation. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_106">
+	  <num style="font-family:'Times New Roman';font-size:13pt">106.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Secondly, in my judgment, to interpret <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> as proposed by the appellant would contradict a fundamental feature of the legislative scheme in TULRCA. Mr Ford relied on the broad thrust of the legislation across time as having always been to comply with article 11 and on Part III as always protecting freedom of association through protecting the right to form and join trade unions. That is too general an approach in circumstances where Parliament has repeatedly and consistently legislated to restrict protection against detriments to cases where workers have undertaken trade union activities at &#8220;an appropriate time&#8221; as defined.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_107">
+	  <num style="font-family:'Times New Roman';font-size:13pt">107.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The reference to &#8220;an appropriate time&#8221; in <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146(2)</ref> draws a clear distinction between trade union activities undertaken outside working hours or with the employer&#8217;s consent, and industrial action, which is generally undertaken during working hours for it to be effective. The distinction limits the protection given by <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> to activities which are not inconsistent with the performance of the primary duties owed by the workers concerned to their employer. The same is true of the substantively identically worded sibling provision, <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> of TULRCA,</span><span style="font-family:'Times New Roman';font-size:11pt"/><span style="font-family:'Times New Roman'">which protects against dismissal on grounds of participating in the activities of an independent trade union at &#8220;an appropriate time&#8221;. TULRCA has expressly drawn a distinction between dismissals dealt with in <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> and the provisions in Part V (sections 237 to 238A) dealing specifically with dismissal for participating in industrial action. The protection in Part V means that <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> cannot be interpreted as extending to encompass protection for participation in lawful industrial action, as to do so would make the Part V provisions otiose and unnecessary. It would be inconsistent with a fundamental feature of the legislation that treats dismissal for industrial action differently from dismissal for other trade union activity.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_108">
+	  <num style="font-family:'Times New Roman';font-size:13pt">108.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The general presumption that the same words used in different sections of the same statute have the same meaning can be rebutted where it is appropriate to do so. But to do so here would create a stark inconsistency between two identically worded provisions. It would also have the effect of conferring on limb (b) workers broader protection in relation to being subjected to a detriment short of dismissal for taking lawful industrial action than on employees in relation to dismissal for taking the same action. It would involve giving <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> a significantly different meaning and scope to <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18/section/152" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 152</ref> that would be inconsistent with the shared source and history of these provisions. The appellant&#8217;s reliance on </span><span style="font-style:italic;font-family:'Times New Roman'">Hurst </span><span style="font-family:'Times New Roman'">to support a conclusion that the two sections can legitimately be interpreted differently is misplaced. Even when interpreting legislation using <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA, the courts cannot and should not ignore the internal coherence of the legislation concerned. Where the new interpretation involves a significant departure from a fundamental feature of the primary legislation concerned, giving rise to possible ramifications that the court is ill-equipped to evaluate, the limits of <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> are reached, and a Convention-compliant interpretation is not possible.</span></p>
+	  </content>
+	</paragraph>
+	<level eId="lvl_11">
+	  <content>
+	    <p class="ParaHeading1"><span style="text-transform:none;font-family:'Times New Roman'">Should a declaration of incompatibility have been made under section 4 of the HRA</span><span style="font-family:'Times New Roman'">?</span></p>
+	  </content>
+	</level>
+	<paragraph eId="para_109">
+	  <num style="font-family:'Times New Roman';font-size:13pt">109.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'"> Having reached the conclusion that a Convention-compliant construction is not possible, the final question is whether the Court of Appeal was correct to decline to make a declaration of incompatibility under section 4 of the HRA. This question did not arise for decision in the EAT given Choudhury J&#8217;s conclusion that a Convention compatible construction of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> was possible but, in any event, it was not possible for the EAT to make such a declaration: see section 4(5) of the HRA. Accordingly, the question arose for the first time in the Court of Appeal, and the Secretary of State did not resist a declaration of incompatibility if his primary argument on article 11 failed and it was thought that a compliant construction was not possible. </span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_110">
+	  <num style="font-family:'Times New Roman';font-size:13pt">110.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The Court of Appeal dealt with this question at paras 82 to 88 of its judgment. It observed that such a declaration, if made, would be directed not so much at <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> as at TULRCA as a whole. At paras 84 and 85, the Court of Appeal held:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;84.</num>
+		  <intro>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In</span><span style="font-style:italic;font-family:'Times New Roman'"> In re S</span><span style="font-family:'Times New Roman'"> Lord Nicholls considered the question of whether, in the alternative to <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42" uk:canonical="1998 c. 42" uk:origin="TNA" uk:type="legislation">the 1998 Act</ref>, a declaration of incompatibility should be made pursuant to section 4. He concluded that it should not. The &#8216;short and conclusive&#8217; reason for this was set out at para 59:</span></p>
+		  </intro>
+		  <subparagraph>
+		    <content>
+		      <p class="Quote" style="margin-left:1.5in"><span style="font-family:'Times New Roman'">&#8216;Failure by the state to provide an effective remedy for a violation of article 8 is not itself a violation of article 8. This is self-evident. So, even if the Children Act does fail to provide an adequate remedy, <ref href="http://www.legislation.gov.uk/id/ukpga/1996/18" uk:canonical="1996 c. 18" uk:origin="TNA" uk:type="legislation">the Act</ref> is not for that reason incompatible with article 8.&#8217;</span></p>
+		    </content>
+		  </subparagraph>
+		</paragraph>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">85.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">That, as it seems to us, is similar to the present case where the real complaint is that TULRCA does not provide the range of protections that article 11 requires.&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_111">
+	  <num style="font-family:'Times New Roman';font-size:13pt">111.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">At para 88 the Court of Appeal concluded:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <num style="font-family:'Times New Roman';font-size:13pt">&#8220;88.</num>
+		  <content>
+		    <p class="Quote" style="margin-left:1in;text-indent:0.5in"><span style="font-family:'Times New Roman'">It would not be appropriate to grant a declaration of incompatibility in this case where there is a lacuna in the law rather than a specific statutory provision which is incompatible (see per Lord Nicholls in </span><span style="font-style:italic;font-family:'Times New Roman'">In Re S</span><span style="font-style:italic;font-weight:bold;font-family:'Times New Roman'"/><span style="font-family:'Times New Roman'"><ref href="#" uk:canonical="[2002] 2 AC 291" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] 2 AC 291</ref>, 319), the extent of the incompatibility is unclear and the legislative choices are far from being binary questions.&#8221;</span></p>
+		  </content>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_112">
+	  <num style="font-family:'Times New Roman';font-size:13pt">112.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The terms of section 4 of the HRA are set out above at para 22 of this judgment. Section 4 sets out the circumstances in which courts may make a &#8220;declaration of incompatibility&#8221;; it specifies which courts have such power; and makes provision for the effect of such a declaration on the legislation in respect of which it is given. It is a discretionary power whose purpose is to draw to the attention of Parliament and the executive an incompatibility that cannot be remedied by the courts. The making of a declaration of incompatibility has been described as &#8220;a measure of last resort&#8221; (see </span><span style="font-style:italic;font-family:'Times New Roman'">R v A (No 2) </span><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/ukhl/2001/25" uk:canonical="[2001] UKHL 25" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2001">[2001] UKHL 25</ref>,</span><span style="font-style:italic;font-family:'Times New Roman'"/><span style="font-family:'Times New Roman'"><ref href="#" uk:canonical="[2002] 1 AC 45" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2002">[2002] 1 AC 45</ref>, at para 44), but that is because a Convention-compliant interpretation under <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/3" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 3</ref> of the HRA is seen as the primary remedial measure.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_113">
+	  <num style="font-family:'Times New Roman';font-size:13pt">113.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">A declaration of incompatibility does not affect the validity, continuing operation, or enforcement of the legislation it concerns and nor is it binding on the parties to the litigation: see section 4(6) of the HRA. It requires no action from the executive or Parliament. If Parliament does not respond to a declaration of incompatibility by amending the legislation in question, the complainant can continue to pursue the matter in Strasbourg: section 4(6)(b). The relevant legislative provision will continue to have force and effect, notwithstanding its incompatibility with Convention rights.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_114">
+	  <num style="font-family:'Times New Roman';font-size:13pt">114.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Mr Stilitz advanced several arguments in support of the Court of Appeal&#8217;s conclusion that a declaration of incompatibility should not be made in this case. He submitted, and I agree, that to make a declaration there must be an identifiable provision in primary legislation which is itself incompatible with the Convention. That is because the express focus of section 4(1) of the HRA is on &#8220;a provision of primary legislation&#8221;. If that provision is found to be incompatible, a declaration of that incompatibility may be made: see section 4(2). A failure by Parliament to legislate is not a breach of the HRA as section 6(6) makes clear: &#8220;&#8216;An act&#8217; includes a failure to act but does not include a failure to &#8211; (a) introduce in, or lay before, Parliament a proposal for legislation; or (b) make any primary legislation or remedial order.&#8221;</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_115">
+	  <num style="font-family:'Times New Roman';font-size:13pt">115.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Furthermore, Mr Stilitz submitted that a failure to provide an effective remedy for a violation of a Convention right is not the same as a violation of the Convention right itself. This was explained by Lord Nicholls in </span><span style="font-style:italic;font-family:'Times New Roman'">In re S (Minors) </span><span style="font-family:'Times New Roman'">in the passage referred to by the Court of Appeal at para 84, cited above. He contended that if there is any failing in the law in the present context it would be by virtue of a general lacuna in the law. There is nothing in the wording of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> that offends against the Convention and the appellant&#8217;s attempts to frame <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> as the &#8220;sole vehicle&#8221; for providing the protection sought are unwarranted. The protection sought could be added anywhere to this statute, or via other legislation and the reality of the appellant&#8217;s case is simply that some legislation should exist (within TULRCA or elsewhere) containing the protections contended for. Applying </span><span style="font-style:italic;font-family:'Times New Roman'">In re S (Minors)</span><span style="font-family:'Times New Roman'">, a section 4 declaration is not appropriate in these circumstances.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_116">
+	  <num style="font-family:'Times New Roman';font-size:13pt">116.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">I have some sympathy for the Court of Appeal&#8217;s conclusion that the failure in this case results from a lacuna in domestic law generally rather than from the intrinsic incompatibility of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref>. Nonetheless, in the end I am persuaded that <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> is the only provision which limits the common law in this context and has the implicit effect of legitimising sanctions short of dismissal imposed for participation in a lawful strike, thereby putting the UK in breach of article 11. That is what is inherently objectionable in the terms of <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA as it stands.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_117">
+	  <num style="font-family:'Times New Roman';font-size:13pt">117.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The appellant&#8217;s complaint is directed at <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA as a specific statutory provision giving rise to the incompatibility complained of, and always has been. If <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> excludes all protection from detriment short of dismissal for participation in lawful industrial action, it is incompatible with article 11 as interpreted in the cases beginning with </span><span style="font-style:italic;font-family:'Times New Roman'">Kara&#231;ay</span><span style="font-family:'Times New Roman'">. On the assumed facts, the appellant has no means of legal redress in domestic law for the detriments to which she has been subjected. Her complaint does not arise because of the application of a statutory scheme which could be applied compatibly with article 11: the sole means of vindicating her article 11 right in the domestic courts or tribunals is blocked by the conventional interpretation given to <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA. On this basis, <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> is incompatible with article 11 of the Convention.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_118">
+	  <num style="font-family:'Times New Roman';font-size:13pt">118.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Having reached the conclusion that <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA is incompatible with article 11, it remains the position that the court is not obliged to make a declaration of incompatibility. Section 4(2) plainly contemplates that there may be circumstances where, despite such a conclusion, it is not appropriate to exercise this power. For example, in </span><span style="font-style:italic;font-family:'Times New Roman'">R (Nicklinson) v Ministry of Justice </span><span style="font-family:'Times New Roman'"><ref href="https://caselaw.nationalarchives.gov.uk/uksc/2014/38" uk:canonical="[2014] UKSC 38" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2014">[2014] UKSC 38</ref>, <ref href="#" uk:canonical="[2015] AC 657" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2015">[2015] AC 657</ref> Lord Neuberger (with whom Lords Mance and Wilson agreed on this question) said at para 114:</span></p>
+	    <block name="embeddedStructure"><embeddedStructure>
+		<paragraph>
+		  <intro>
+		    <p class="Quote" style="margin-left:1in"><span style="font-family:'Times New Roman'">&#8220;It would, of course, be unusual for a court to hold that a statutory provision, conventionally construed, infringed a Convention right and could not be construed compatibly with it, and yet to refuse to make a declaration under <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/4" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 4</ref> of <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42" uk:canonical="1998 c. 42" uk:origin="TNA" uk:type="legislation">the 1998 Act</ref>. However, there can be no doubt that there is such a power: <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/4/2" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 4(2)</ref> states that if there is an incompatibility, the court &#8216;may&#8217; make a declaration to that effect, and the power to grant declaratory relief is anyway inherently discretionary. The possibility of not granting a declaration of incompatibility to enable the legislature to consider the position is by no means a novel notion. As pointed out by &#8230; Lord Nicholls in </span><span style="font-style:italic;font-family:'Times New Roman'">Bellinger v Bellinger</span><span style="font-family:'Times New Roman'"> <ref href="#" uk:canonical="[2003] 2 AC 467" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2003">[2003] 2 AC 467</ref>, para 53 said:</span></p>
+		  </intro>
+		  <subparagraph>
+		    <content>
+		      <p class="Quote" style="margin-left:1.5in"><span style="font-family:'Times New Roman'">&#8216;It may also be that there are circumstances where maintaining an offending law in operation for a reasonable period pending enactment of corrective legislation is justifiable. An individual may not then be able, during the transitional period, to complain that his rights have been violated. The admissibility decision of the court in </span><span style="font-style:italic;font-family:'Times New Roman'">Walden v Liechtenstein</span><span style="font-family:'Times New Roman'"> (Application No 33916/96) (unreported) 16 March 2000 is an example of this pragmatic approach to the practicalities of government.&#8217;&#8221;</span></p>
+		    </content>
+		  </subparagraph>
+		</paragraph>
+	      </embeddedStructure></block>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_119">
+	  <num style="font-family:'Times New Roman';font-size:13pt">119.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">The circumstances in which self-restraint in this regard should be exercised have not been comprehensively catalogued for reasons that are understandable (as Lord Kerr observed in </span><span style="font-style:italic;font-family:'Times New Roman'">R (Steinfeld) v Secretary of State for International Development</span><span style="font-family:'Times New Roman'"> <ref href="https://caselaw.nationalarchives.gov.uk/uksc/2018/32" uk:canonical="[2018] UKSC 32" uk:isNeutral="true" uk:origin="TNA" uk:type="case" uk:year="2018">[2018] UKSC 32</ref>, <ref href="#" uk:canonical="[2020] AC 1" uk:isNeutral="false" uk:origin="TNA" uk:type="case" uk:year="2020">[2020] AC 1</ref> at para 57). The wide variety of circumstances in which the court may be called upon to make a declaration make it difficult to identify particular considerations favouring one course rather than the other.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_120">
+	  <num style="font-family:'Times New Roman';font-size:13pt">120.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">In my view this is not one of those cases where it is inappropriate to make a declaration of incompatibility. The ultimate legislative solution to the problem identified in this case may call for enquiry. Questions of policy will have to be addressed and evaluated, their practical ramifications considered, and a fair balance struck between all the competing interests at stake. But the existence of policy choices in the means of giving effect to the lawful strike rights protected by article 11 is a reason in favour of making a declaration of incompatibility, not refusing one. It is for Parliament to decide whether to legislate and, if so, the scope and nature of such protection. Moreover, resolution of these issues being pre-eminently a matter for Parliament, it may consider that <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> is not after all the correct vehicle to remedy the problem. That too is not a reason for refusing a declaration in this case. No legislation is pending or envisaged in this area, that might make it premature to make a declaration. Indeed, I can discern no good reason for rejecting the remedial measure provided for by <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/4" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 4</ref> of the HRA by making such a declaration.</span></p>
+	  </content>
+	</paragraph>
+	<paragraph eId="para_121">
+	  <num style="font-family:'Times New Roman';font-size:13pt">121.</num>
+	  <content>
+	    <p class="ParaApprovedLevel1" style="margin-left:0in;text-indent:0.5in"><span style="font-family:'Times New Roman'">Accordingly, I would make a declaration under <ref href="http://www.legislation.gov.uk/id/ukpga/1998/42/section/4" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 4</ref> of the HRA that <ref href="http://www.legislation.gov.uk/id/ukpga/1992/52/section/146" uk:canonical="" uk:origin="TNA" uk:type="legislation">section 146</ref> of TULRCA is incompatible with article 11, insofar as it fails to provide any protection against sanctions, short of dismissal, intended to deter or penalise trade union members from taking part in lawful strike action organised by their trade union. To that extent, I would allow this appeal.</span></p>
+	  </content>
+	</paragraph>
+      </decision>
+    </judgmentBody>
+  </judgment>
+</akomaNtoso>

--- a/tests/test_phase4_drilldown.py
+++ b/tests/test_phase4_drilldown.py
@@ -1,0 +1,192 @@
+"""Phase 4 tests — case_law judgment drill-down.
+
+Two layers:
+
+* **Offline parser tests** — load a committed real judgment fixture
+  (UKSC 2024/12, the 226KB judgment that originally failed the audit).
+  Deterministic, fast, no network.
+
+* **Live gateway tests** — exercise the resources + grep tool through
+  an in-process FastMCP Client. Hits TNA Find Case Law (no WAF risk).
+"""
+
+import statistics
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+
+from src.gateway import gateway
+from src.modules.case_law import parsers
+
+FIXTURE = Path(__file__).parent / "live" / "fixtures" / "uksc_2024_12_full.xml"
+
+
+def _xml() -> str:
+    return FIXTURE.read_text()
+
+
+def _est_tokens(s: str) -> int:
+    return len(s) // 4
+
+
+# ─── Offline parser tests ──────────────────────────────────────────────────
+
+def test_extract_index_returns_one_row_per_paragraph_with_eid():
+    out = parsers.extract_index(_xml())
+    rows = out.splitlines()
+    assert len(rows) == 121  # measured count for UKSC 2024/12
+    for row in rows:
+        eid, _, _ = row.partition(": ")
+        assert eid.startswith("para_")
+
+
+def test_extract_index_under_5000_tokens():
+    """The audit-acceptance gate, offline."""
+    out = parsers.extract_index(_xml())
+    assert _est_tokens(out) < 5_000, f"index ≈ {_est_tokens(out)} tokens, target <5000"
+
+
+def test_extract_header_under_2000_tokens():
+    out = parsers.extract_header(_xml())
+    assert out.startswith("<header") or "<akn:header" in out
+    assert _est_tokens(out) < 2_000
+
+
+def test_extract_paragraph_returns_single_para():
+    out = parsers.extract_paragraph(_xml(), "para_1")
+    assert "<paragraph" in out
+    assert 'eId="para_1"' in out
+    # And no second paragraph snuck in
+    assert out.count("<paragraph") < 5  # may contain nested sub-paragraphs
+
+
+def test_extract_paragraph_p99_under_2000_tokens():
+    """Statistical assertion — even the longest paragraph stays small."""
+    xml = _xml()
+    sizes = []
+    for n in range(1, 122):
+        try:
+            out = parsers.extract_paragraph(xml, f"para_{n}")
+            sizes.append(_est_tokens(out))
+        except KeyError:
+            pass
+    assert len(sizes) > 100
+    p99 = sorted(sizes)[int(len(sizes) * 0.99)]
+    assert p99 < 2_000, f"p99 paragraph ≈ {p99} tokens"
+
+
+def test_extract_paragraph_raises_for_unknown_eid():
+    with pytest.raises(KeyError):
+        parsers.extract_paragraph(_xml(), "para_99999")
+
+
+def test_grep_finds_matches_with_snippets():
+    hits = parsers.grep_paragraphs(_xml(), "appellant", max_hits=5)
+    assert hits, "should match at least one paragraph"
+    for h in hits:
+        assert h["eId"].startswith("para_")
+        assert "appellant" in h["snippet"].lower()
+        assert h["match"]
+
+
+def test_grep_respects_max_hits_cap():
+    hits = parsers.grep_paragraphs(_xml(), "the", max_hits=3)
+    assert len(hits) == 3
+
+
+def test_grep_case_insensitive_default():
+    a = parsers.grep_paragraphs(_xml(), "APPELLANT", max_hits=10)
+    b = parsers.grep_paragraphs(_xml(), "appellant", max_hits=10)
+    assert len(a) == len(b)
+
+
+def test_grep_falls_back_to_literal_on_invalid_regex():
+    # Unbalanced bracket — still matches as literal
+    hits = parsers.grep_paragraphs(_xml(), "[unclosed", max_hits=5)
+    # Literal "[unclosed" almost certainly absent; just assert no crash
+    assert isinstance(hits, list)
+
+
+# ─── Live gateway tests ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_three_resource_templates_registered():
+    async with Client(gateway) as c:
+        templates = {t.uriTemplate for t in await c.list_resource_templates()}
+    assert "judgment://{slug*}/header" in templates
+    assert "judgment://{slug*}/index" in templates
+    assert "judgment://{slug*}/para/{eId}" in templates
+    # And the bare wildcard is gone
+    assert "judgment://{slug*}" not in templates
+
+
+@pytest.mark.asyncio
+async def test_grep_judgment_tool_registered():
+    async with Client(gateway) as c:
+        tools = {t.name for t in await c.list_tools()}
+    assert "case_law_grep_judgment" in tools
+    assert "case_law_get_judgment" not in tools  # deleted
+
+
+@pytest.mark.asyncio
+async def test_resources_as_tools_transform_exposes_read_resource_tool():
+    async with Client(gateway) as c:
+        tools = {t.name for t in await c.list_tools()}
+    assert "read_resource" in tools
+    assert "list_resources" in tools
+
+
+@pytest.mark.asyncio
+async def test_judgment_index_under_5k_tokens_live():
+    """End-to-end audit-acceptance check against the real TNA endpoint."""
+    async with Client(gateway) as c:
+        result = await c.read_resource("judgment://uksc/2024/12/index")
+    text = result[0].text
+    assert _est_tokens(text) < 5_000
+
+
+@pytest.mark.asyncio
+async def test_judgment_para_returns_single_paragraph_live():
+    async with Client(gateway) as c:
+        result = await c.read_resource("judgment://uksc/2024/12/para/para_1")
+    text = result[0].text
+    assert 'eId="para_1"' in text
+    assert _est_tokens(text) < 2_000
+
+
+@pytest.mark.asyncio
+async def test_grep_judgment_tool_returns_hits_live():
+    async with Client(gateway) as c:
+        result = await c.call_tool(
+            "case_law_grep_judgment",
+            {"params": {"slug": "uksc/2024/12", "pattern": "appellant", "max_hits": 5}},
+        )
+    payload = result.data
+    assert payload.slug == "uksc/2024/12"
+    assert len(payload.hits) > 0
+    for h in payload.hits:
+        assert "appellant" in h.snippet.lower()
+
+
+@pytest.mark.asyncio
+async def test_typical_workflow_under_7k_tokens():
+    """Integration check: header + grep + 2 paragraphs ≤ 7k tokens.
+
+    Mirrors the realistic 'what did the judges say about X?' flow.
+    """
+    async with Client(gateway) as c:
+        header = await c.read_resource("judgment://uksc/2024/12/header")
+        grep = await c.call_tool(
+            "case_law_grep_judgment",
+            {"params": {"slug": "uksc/2024/12", "pattern": "regulations", "max_hits": 5}},
+        )
+        # Read first 2 hit paragraphs
+        para_texts = []
+        for hit in grep.data.hits[:2]:
+            r = await c.read_resource(f"judgment://uksc/2024/12/para/{hit.eId}")
+            para_texts.append(r[0].text)
+
+    total_text = header[0].text + str(grep.data) + "".join(para_texts)
+    total_tokens = _est_tokens(total_text)
+    assert total_tokens < 7_000, f"workflow used ≈ {total_tokens} tokens"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -20,37 +20,26 @@ from src.gateway import gateway
 
 
 @pytest.mark.asyncio
-async def test_resource_templates_registered_at_gateway():
-    """The three Phase 3 resource templates must be exposed."""
+async def test_legislation_resource_templates_registered():
+    """Phase 3 legislation resource templates must be exposed.
+
+    Case-law resource templates are covered by tests/test_phase4_drilldown.py.
+    """
     async with Client(gateway) as client:
         templates = {t.uriTemplate for t in await client.list_resource_templates()}
 
-    assert "judgment://{slug*}" in templates
     assert "legislation://{type}/{year}/{number}/section/{section}" in templates
     assert "legislation://{type}/{year}/{number}/toc" in templates
 
 
 @pytest.mark.asyncio
-async def test_judgment_resource_returns_legaldocml():
-    """Reading a known TNA judgment slug returns LegalDocML XML."""
-    async with Client(gateway) as client:
-        result = await client.read_resource("judgment://uksc/2024/12")
-
-    assert len(result) == 1
-    text = result[0].text
-    assert text.startswith("<akomaNtoso")
-    assert "legaldocml" in text or "akn/3.0" in text
-    assert len(text) > 10_000  # Non-trivial judgment
-
-
-@pytest.mark.asyncio
-async def test_judgment_resource_handles_deep_slug():
-    """Multi-segment wildcard slug ('ewca/civ/2023/N') routes correctly."""
+async def test_judgment_wildcard_substitution_handles_deep_slug():
+    """Multi-segment wildcard slug ('ewca/civ/2023/N') routes correctly via a sub-path."""
     async with Client(gateway) as client:
         # 404 is expected for a made-up slug; the test is that the URL is
         # constructed with the wildcard substituted, not that this case exists.
         with pytest.raises(Exception) as exc_info:
-            await client.read_resource("judgment://ewca/civ/2099/99999")
+            await client.read_resource("judgment://ewca/civ/2099/99999/header")
 
     msg = str(exc_info.value)
     assert "ewca/civ/2099/99999" in msg, (


### PR DESCRIPTION
Closes #6.

## What

Replace the bare `judgment://{slug*}` resource (which returned **56k tokens** of full XML for a typical Supreme Court judgment — the only audit FAIL) with three sub-path templates plus one search tool.

## Surface

| Type | Name | Returns | Tokens (UKSC 2024/12) |
|---|---|---|---|
| Resource | `judgment://{slug*}/header` | metadata, parties, judges | **902** |
| Resource | `judgment://{slug*}/index` | `eId: first_line` per paragraph | **3,935** |
| Resource | `judgment://{slug*}/para/{eId}` | single paragraph | 438 (median), 1,669 (max) |
| Tool | `case_law_grep_judgment` | regex search; returns `[{eId, snippet, match}]` | ~500 per typical query |

Plus `ResourcesAsTools(gateway)` transform applied at gateway level — auto-generates `list_resources` + `read_resource` tools so tool-only clients (Apps, ChatGPT) get full coverage with no hand-written wrappers.

## Deleted

`case_law_get_judgment` tool — superseded by the drill-down resources. No back-compat needed (Phase 3 only shipped today).

## Why this shape

Walking real LLM workflows showed the gap that needed grep + index together:

| Question | Header | Index | Grep |
|---|---|---|---|
| "Who were the parties?" | ✅ | — | — |
| "Summarise paragraphs 12-15" | — | ✅ | — |
| "What did Lord X say about negligence?" | silent | guess | **needed** |
| "Did this case cite *Donoghue*?" | — | unreliable | **needed** |

A typical content-question flow: `header (1k) + grep (~500) + 2-3 paragraphs (3k) ≈ 5-6k tokens` vs **56k for the current full read.**

## Tests

- `tests/test_phase4_drilldown.py` — 17 tests (10 offline against committed fixture + 7 live against TNA), all green
- `tests/test_resources.py` — updated to drop the deleted bare-slug template, kept the wildcard-substitution test using a sub-path
- Fixture committed: `tests/live/fixtures/uksc_2024_12_full.xml` (226KB UKSC 2024/12, force-added since tests/live/fixtures was gitignored)
- Full suite: **57/57 passed**

## Verification post-deploy

```bash
fly deploy --app uk-legal-mcp --remote-only
fly machine restart 48e453ebe663d8 -a bouch-mcp-bridge
cd ../bouch-pages
# Update fleet_token_audit.py probe to:
#   tool="read_resource", args={"uri": "judgment://uksc/2024/12/index"}
uv run --with fastmcp --with tiktoken --with httpx \
    python tools/fleet_token_audit.py
```

**Acceptance:** zero FAIL. Index probe under 5k tokens. The integration test `test_typical_workflow_under_7k_tokens` already proves the realistic answer-flow stays under 7k tokens of context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)