### PR TITLE
feat(search): add next_steps URI hints to search results

### DIFF
--- a/src/modules/case_law/models.py
+++ b/src/modules/case_law/models.py
@@ -32,6 +32,17 @@ class JudgmentSummary(BaseModel):
     content_hash: str | None = Field(None, description="SHA256 of body text — use for change detection in polling loops")
     xml_url: str | None = Field(None, description="URL to LegalDocML XML source")
     pdf_url: str | None = Field(None, description="URL to PDF version")
+    next_steps: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Canonical resource URIs and the search-within tool for reading "
+            "this judgment. Read `header` first for orientation (~1k tokens), "
+            "then `index` to discover paragraph eIds (~4k tokens), then "
+            "`paragraph_template` (substitute the eId from the index) for "
+            "specific paragraphs (~400-1700 tokens each). Use `grep_tool` for "
+            "content discovery instead of brute-forcing every paragraph."
+        ),
+    )
 
 
 class JudgmentSearchResult(BaseModel):

--- a/src/modules/case_law/tools.py
+++ b/src/modules/case_law/tools.py
@@ -125,6 +125,12 @@ def _parse_atom_feed(xml_bytes: bytes) -> JudgmentSearchResult:
                 identifiers=identifiers,
                 content_hash=hashlib.sha256((xml_url or "").encode()).hexdigest() if xml_url else None,
                 xml_url=xml_url, pdf_url=pdf_url,
+                next_steps=({
+                    "header": f"judgment://{slug}/header",
+                    "index": f"judgment://{slug}/index",
+                    "paragraph_template": f"judgment://{slug}/para/{{eId}}",
+                    "grep_tool": f"case_law_grep_judgment(slug={slug!r}, pattern=...)",
+                } if slug else {}),
             ))
         return JudgmentSearchResult(
             results=summaries, page=current_page,

--- a/src/modules/legislation/models.py
+++ b/src/modules/legislation/models.py
@@ -30,6 +30,15 @@ class LegislationResult(BaseModel):
     number: int = Field(..., description="Chapter or SI number")
     score: float | None = Field(None, description="Relevance score from Lex API (higher = more relevant)")
     url: str = Field(..., description="Canonical legislation.gov.uk URL")
+    next_steps: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Canonical resource URIs for reading this Act/SI. Read `toc` to "
+            "discover sections, then `section_template` (substitute the section "
+            "number) for the section text. Both URIs accept an optional "
+            "?date=YYYY-MM-DD query for point-in-time historical research."
+        ),
+    )
 
 
 class LegislationSearchResult(BaseModel):

--- a/src/modules/legislation/tools.py
+++ b/src/modules/legislation/tools.py
@@ -206,6 +206,11 @@ def register_tools(mcp: FastMCP) -> None:
             results.append(LegislationResult(
                 title=title, type=leg_type, year=yr, number=num,
                 score=None, url=f"{LEGISLATION_BASE}/{leg_type}/{yr}/{num}",
+                next_steps=({
+                    "toc": f"legislation://{leg_type}/{yr}/{num}/toc",
+                    "section_template": f"legislation://{leg_type}/{yr}/{num}/section/{{section}}",
+                    "point_in_time_hint": "Append ?date=YYYY-MM-DD to either URI for historical research",
+                } if leg_type != "unknown" else {}),
             ))
 
         return LegislationSearchResult(results=results, total=total or len(results))

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -48,6 +48,20 @@ async def test_legislation_search_default_finds_named_act():
     top3 = [(r.type, r.year, r.number) for r in result.data.results[:3]]
     assert ("ukpga", 1988, 50) in top3, f"Top 3 was {top3}"
 
+    # Each result should include canonical resource URIs in next_steps.
+    # We assert against the raw JSON wire format (what LLM clients actually
+    # consume) rather than result.data — fastmcp's Python Client materialises
+    # dict[str, str] fields as an empty Root sentinel, but the JSON on the
+    # wire is correct and visible to Codex / claude.ai / ChatGPT.
+    import json as _json
+    payload = _json.loads(result.content[0].text)
+    first = payload["results"][0]
+    assert first["next_steps"], "Expected next_steps hints on each result"
+    assert "toc" in first["next_steps"]
+    assert "section_template" in first["next_steps"]
+    expected_toc = f"legislation://{first['type']}/{first['year']}/{first['number']}/toc"
+    assert first["next_steps"]["toc"] == expected_toc
+
 
 @pytest.mark.asyncio
 async def test_judgment_wildcard_substitution_handles_deep_slug():


### PR DESCRIPTION
Removes the discoverability friction Codex hit on the UKSC 2024/12 test today.

## Problem

Codex's first call after `case_law_search` was to the deleted `case_law_get_judgment` tool. It then needed an extra `list_resources` call to discover the new drill-down surface. ~2 wasted tool calls per workflow.

## Fix

Each search result item now carries a `next_steps: dict[str, str]` field with the canonical resource URIs (and grep tool) for that specific item. Labelled keys teach the workflow at the same time as giving the URIs to use.

## Shape

```json
// JudgmentSummary.next_steps for uksc/2024/12
{
  "header": "judgment://uksc/2024/12/header",
  "index": "judgment://uksc/2024/12/index",
  "paragraph_template": "judgment://uksc/2024/12/para/{eId}",
  "grep_tool": "case_law_grep_judgment(slug='uksc/2024/12', pattern=...)"
}

// LegislationResult.next_steps for ukpga/1988/50
{
  "toc": "legislation://ukpga/1988/50/toc",
  "section_template": "legislation://ukpga/1988/50/section/{section}",
  "point_in_time_hint": "Append ?date=YYYY-MM-DD to either URI for historical research"
}
```

## Wire-format note

fastmcp's Python `Client` materialises `dict[str, str]` as an empty `Root` sentinel — but the JSON on the wire is correct (Codex / claude.ai / ChatGPT see the populated dict). The new test assertion reads `result.content[0].text` directly, which is what LLM clients actually consume.

## Tests

- Updated `test_legislation_search_default_finds_named_act` to assert `next_steps` populated and URIs match the result's identifier
- Full suite: **59/59 passed**

## Out of scope

`govuk_search` gets the same treatment in a separate PR on govuk-mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)