### PR TITLE
fix: claude.ai compatibility via held-open GET SSE stream

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,44 @@
+name: Fly.io Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: read
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    # Do not expose Fly deploy credentials to fork PRs.
+    # Fork PRs do not receive repository secrets anyway, except GITHUB_TOKEN.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    concurrency:
+      group: fly-preview-pr-${{ github.event.number }}
+      cancel-in-progress: true
+    environment:
+      name: pr-${{ github.event.number }}
+      url: ${{ steps.deploy.outputs.url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare review Fly config
+        run: |
+          cp fly.toml fly.review.toml
+          # Review apps should scale to zero when idle.
+          perl -0pi -e 's/auto_stop_machines = "off"/auto_stop_machines = "stop"/' fly.review.toml
+          perl -0pi -e 's/min_machines_running = 1/min_machines_running = 0/' fly.review.toml
+
+      - name: Deploy FastMCP preview server
+        id: deploy
+        uses: superfly/fly-pr-review-apps@1.5.0
+        with:
+          name: uk-legal-mcp-pr-${{ github.event.number }}
+          config: fly.review.toml
+          region: lhr
+          org: personal
+          memory: "512"

--- a/src/gateway.py
+++ b/src/gateway.py
@@ -324,6 +324,59 @@ async def glama_connector_manifest(request: Request) -> Response:
 # Entrypoint
 # ---------------------------------------------------------------------------
 
+class _HttpGuard:
+    """Return a held-open SSE stream for GET /mcp; 405 for DELETE /mcp.
+
+    claude.ai proxies all MCP traffic through its own relay. The browser opens a
+    GET to that relay to establish an SSE stream for server-initiated messages;
+    the relay forwards the GET here. With stateless_http=True FastMCP only registers
+    POST+DELETE, so GET 405s — the relay relays the 405 and the connection fails,
+    even though POST works fine. (OpenAI never probes GET, so it was unaffected.)
+
+    Fix: intercept GET /mcp and return 200 text/event-stream held open until the
+    client disconnects. FastMCP never sees the GET; stateless semantics are preserved.
+    DELETE is rejected (405) — stateless servers have no sessions to terminate.
+    """
+    def __init__(self, app, mcp_path: bytes = b"/mcp"):
+        self.app = app
+        self._mcp_path = mcp_path.rstrip(b"/")
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") == "http":
+            path = scope.get("path", "").rstrip("/").encode()
+            method = scope.get("method", "").upper().encode()
+            if path == self._mcp_path:
+                if method == b"GET":
+                    await send({
+                        "type": "http.response.start",
+                        "status": 200,
+                        "headers": [
+                            (b"content-type", b"text/event-stream"),
+                            (b"cache-control", b"no-cache"),
+                            (b"connection", b"keep-alive"),
+                        ],
+                    })
+                    await send({
+                        "type": "http.response.body",
+                        "body": b"",
+                        "more_body": True,
+                    })
+                    while True:
+                        event = await receive()
+                        if event["type"] == "http.disconnect":
+                            break
+                    return
+                if method == b"DELETE":
+                    from starlette.responses import Response as StarletteResponse
+                    await StarletteResponse(
+                        "Method Not Allowed",
+                        status_code=405,
+                        headers={"Allow": "POST"},
+                    )(scope, receive, send)
+                    return
+        await self.app(scope, receive, send)
+
+
 class _AcceptNormalizer:
     """Stamp Accept to the MCP-spec value on /mcp only, so json_response=True never 406s.
 
@@ -364,7 +417,7 @@ def main() -> None:
         stateless_http=True,
     )
     uvicorn.run(
-        _AcceptNormalizer(app),
+        _HttpGuard(_AcceptNormalizer(app)),  # guard → normalizer → FastMCP
         host="0.0.0.0",
         port=port,
         forwarded_allow_ips="*",


### PR DESCRIPTION
## Summary

- **Root cause confirmed** (browser DevTools): claude.ai proxies all MCP traffic through its relay. The browser opens a GET to establish an SSE stream; the relay forwards the GET to our server. With `stateless_http=True`, FastMCP only registers POST+DELETE routes — GET returns 405, the relay relays it, connection fails. OpenAI never probes GET, which is why it worked there.
- Adds `_HttpGuard` ASGI middleware (outermost) that intercepts GET `/mcp` and returns a held-open `200 text/event-stream` response until the client disconnects. FastMCP never sees the GET.
- DELETE is also intercepted and rejected with 405 (stateless servers have no sessions to terminate).
- `stateless_http=True` and `json_response=True` are unchanged — still required for multi-machine Fly correctness and Claude Code compatibility respectively.
- Adds `preview.yml` to deploy a Fly.io preview app on this PR for end-to-end testing.

## Test plan

- [ ] Preview app deploys via GitHub Actions (`uk-legal-mcp-pr-N.fly.dev`)
- [ ] `GET /mcp` returns `200 text/event-stream` (held open): `curl -v -X GET https://uk-legal-mcp-pr-N.fly.dev/mcp -H "Accept: text/event-stream"`
- [ ] `POST /mcp` initialize still returns `200` JSON — existing Claude Code and OpenAI clients unaffected
- [ ] `DELETE /mcp` returns `405`
- [ ] Connect preview URL from claude.ai settings → tools appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)