### PR TITLE
feat: legislation HTML fallback + stdio entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ Documentation = "https://github.com/paulieb89/uk-legal-mcp#readme"
 "Live Endpoint" = "https://uk-legal-mcp.fly.dev/mcp"
 
 [project.scripts]
-uk-legal-mcp = "src.gateway:main"
+uk-legal-mcp = "src.gateway:main_stdio"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
@@ -74,4 +74,11 @@ exclude = [
 dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
+    "tiktoken>=0.12.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+markers = [
+    "live: hits live external APIs — excluded from offline CI (deselect with -m 'not live')",
 ]

--- a/src/deps.py
+++ b/src/deps.py
@@ -137,6 +137,31 @@ class LegislationClient:
 
         return resp
 
+    async def get_html(self, url: str, **kwargs):
+        """GET an HTML legislation page.
+
+        This is used as a last-resort fallback when legislation.gov.uk's
+        CLML /data.xml endpoint is blocked or returns an async-rendering
+        placeholder. It deliberately keeps the same WAF detection as XML
+        fetches so callers do not accidentally parse a challenge page as law.
+        """
+        headers = dict(kwargs.pop("headers", {}) or {})
+        headers.setdefault("Accept", "text/html,application/xhtml+xml")
+        resp = await self._session.get(url, headers=headers, **kwargs)
+        ct = (resp.headers.get("content-type") or "").lower()
+        if "html" in ct and any(m in resp.text for m in self.WAF_MARKERS):
+            raise LegislationUpstreamError(
+                f"legislation.gov.uk returned an AWS WAF JavaScript challenge "
+                f"for {url}. XML and HTML fallback are both unavailable. "
+                f"Retry later or use legislation_search(fulltext=True)."
+            )
+        if not resp.content.strip():
+            raise LegislationUpstreamError(
+                f"legislation.gov.uk returned an empty HTML response for {url}. "
+                f"Retry later or use legislation_search(fulltext=True)."
+            )
+        return resp
+
 
 # ---------------------------------------------------------------------------
 # Lifespan factory — attach to each sub-module FastMCP instance

--- a/src/gateway.py
+++ b/src/gateway.py
@@ -261,7 +261,7 @@ async def judgment_get_index(
 )
 async def judgment_get_paragraph(
     slug: Annotated[str, Field(description="Judgment slug, e.g. 'uksc/2024/12'", min_length=3, max_length=200)],
-    eId: Annotated[str, Field(description="Paragraph eId from judgment_get_index, e.g. 'para_12'", min_length=1, max_length=100)],
+    eId: Annotated[str, Field(description="Paragraph eId from judgment_get_index, e.g. 'para_12'. Numeric strings like '12' are accepted and normalized to 'para_12'.", min_length=1, max_length=100)],
     ctx: Context,
 ) -> dict:
     """Get a single paragraph from a UK court judgment by its LegalDocML eId.
@@ -273,8 +273,11 @@ async def judgment_get_paragraph(
     client: httpx.AsyncClient = ctx.lifespan_context["xml_http"]
     resp = await client.get(f"{TNA_BASE}/{slug.lstrip('/')}/data.xml")
     resp.raise_for_status()
-    content = case_law_parsers.extract_paragraph(resp.text, eId)
-    return {"slug": slug, "eId": eId, "content": content}
+    normalized_eid = eId.strip()
+    if normalized_eid.isdigit():
+        normalized_eid = f"para_{normalized_eid}"
+    content = case_law_parsers.extract_paragraph(resp.text, normalized_eid)
+    return {"slug": slug, "eId": normalized_eid, "content": content}
 
 
 # ---------------------------------------------------------------------------
@@ -324,6 +327,59 @@ async def glama_connector_manifest(request: Request) -> Response:
 # Entrypoint
 # ---------------------------------------------------------------------------
 
+class _HttpGuard:
+    """Return a held-open SSE stream for GET /mcp; 405 for DELETE /mcp.
+
+    claude.ai proxies all MCP traffic through its own relay. The browser opens a
+    GET to that relay to establish an SSE stream for server-initiated messages;
+    the relay forwards the GET here. With stateless_http=True FastMCP only registers
+    POST+DELETE, so GET 405s — the relay relays the 405 and the connection fails,
+    even though POST works fine. (OpenAI never probes GET, so it was unaffected.)
+
+    Fix: intercept GET /mcp and return 200 text/event-stream held open until the
+    client disconnects. FastMCP never sees the GET; stateless semantics are preserved.
+    DELETE is rejected (405) — stateless servers have no sessions to terminate.
+    """
+    def __init__(self, app, mcp_path: bytes = b"/mcp"):
+        self.app = app
+        self._mcp_path = mcp_path.rstrip(b"/")
+
+    async def __call__(self, scope, receive, send):
+        if scope.get("type") == "http":
+            path = scope.get("path", "").rstrip("/").encode()
+            method = scope.get("method", "").upper().encode()
+            if path == self._mcp_path:
+                if method == b"GET":
+                    await send({
+                        "type": "http.response.start",
+                        "status": 200,
+                        "headers": [
+                            (b"content-type", b"text/event-stream"),
+                            (b"cache-control", b"no-cache"),
+                            (b"connection", b"keep-alive"),
+                        ],
+                    })
+                    await send({
+                        "type": "http.response.body",
+                        "body": b"",
+                        "more_body": True,
+                    })
+                    while True:
+                        event = await receive()
+                        if event["type"] == "http.disconnect":
+                            break
+                    return
+                if method == b"DELETE":
+                    from starlette.responses import Response as StarletteResponse
+                    await StarletteResponse(
+                        "Method Not Allowed",
+                        status_code=405,
+                        headers={"Allow": "POST"},
+                    )(scope, receive, send)
+                    return
+        await self.app(scope, receive, send)
+
+
 class _AcceptNormalizer:
     """Stamp Accept to the MCP-spec value on /mcp only, so json_response=True never 406s.
 
@@ -364,7 +420,7 @@ def main() -> None:
         stateless_http=True,
     )
     uvicorn.run(
-        _AcceptNormalizer(app),
+        _HttpGuard(_AcceptNormalizer(app)),  # guard → normalizer → FastMCP
         host="0.0.0.0",
         port=port,
         forwarded_allow_ips="*",
@@ -372,6 +428,11 @@ def main() -> None:
         lifespan="on",
         log_level="info",
     )
+
+
+def main_stdio() -> None:
+    """Run the gateway on stdio transport (for PyPI install / Claude Desktop)."""
+    gateway.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/src/modules/legislation/models.py
+++ b/src/modules/legislation/models.py
@@ -110,10 +110,10 @@ class LegislationSection(BaseModel):
     in_force: bool | None = Field(None, description="Whether this section is currently in force; None if unknown")
     extent: list[str] = Field(
         default_factory=list,
-        description="Territorial extent: list of 'England', 'Wales', 'Scotland', 'Northern Ireland'",
+        description="Territorial extent: list of 'England', 'Wales', 'Scotland', 'Northern Ireland'. Empty list means unknown — do not assume full UK extent.",
     )
     version_date: date | None = Field(None, description="Date of the version retrieved")
-    prospective: bool = Field(False, description="True if this section has not yet come into force")
+    prospective: bool | None = Field(None, description="True if this section has not yet come into force; None if unknown")
     source_format: Literal["xml", "html_fallback"] = Field(
         "xml",
         description="Source parsed for this response. html_fallback means CLML XML was unavailable and text was parsed from the public HTML page.",

--- a/src/modules/legislation/models.py
+++ b/src/modules/legislation/models.py
@@ -114,3 +114,11 @@ class LegislationSection(BaseModel):
     )
     version_date: date | None = Field(None, description="Date of the version retrieved")
     prospective: bool = Field(False, description="True if this section has not yet come into force")
+    source_format: Literal["xml", "html_fallback"] = Field(
+        "xml",
+        description="Source parsed for this response. html_fallback means CLML XML was unavailable and text was parsed from the public HTML page.",
+    )
+    warnings: list[str] = Field(
+        default_factory=list,
+        description="Non-fatal retrieval or parsing warnings the caller should disclose where relevant.",
+    )

--- a/src/modules/legislation/tools.py
+++ b/src/modules/legislation/tools.py
@@ -12,10 +12,10 @@ from datetime import date
 
 import httpx
 from fastmcp import FastMCP, Context
-from lxml import etree
+from lxml import etree, html
 from pydantic import BaseModel, ConfigDict, Field
 
-from ...deps import format_http_error
+from ...deps import LegislationUpstreamError, format_http_error
 from .models import LegislationResult, LegislationSearchResult, LegislationSection, LegislationTOC
 
 LEGISLATION_BASE = "https://www.legislation.gov.uk"
@@ -93,6 +93,66 @@ class LegislationGetTocInput(BaseModel):
     )
 
 
+def _normalise_section_id(section: str) -> str:
+    """Accept common TOC/resource forms and return the section token expected upstream."""
+    value = section.strip()
+    if ":" in value:
+        value = value.split(":", 1)[0].strip()
+    for prefix in ("section-", "article-", "regulation-"):
+        if value.lower().startswith(prefix):
+            return value[len(prefix):]
+    return value
+
+
+def _parse_html_section(html_text: str, section: str, max_chars: int, warning: str) -> LegislationSection:
+    """Best-effort parser for legislation.gov.uk HTML section pages.
+
+    This fallback intentionally returns conservative metadata. It is better to
+    return the section text with explicit unknowns than to fail hard when the
+    CLML endpoint is blocked for large Acts.
+    """
+    root = html.fromstring(html_text.encode())
+
+    candidates = root.xpath(
+        "//*[@id='content'] | //*[@id='viewLegSnippet'] | //*[@class='LegSnippet'] | "
+        "//main | //article | //body"
+    )
+    container = candidates[0] if candidates else root
+
+    # Remove navigation/chrome that tends to pollute section text.
+    for noisy in container.xpath(".//script | .//style | .//nav | .//footer | .//header | .//form"):
+        parent = noisy.getparent()
+        if parent is not None:
+            parent.remove(noisy)
+
+    raw_content = " ".join(container.text_content().split())
+    original_length = len(raw_content)
+    truncated = original_length > max_chars
+    content = raw_content[:max_chars] + " …[truncated]" if truncated else raw_content
+
+    title = f"Section {section}"
+    heading = container.xpath(".//h1/text() | .//h2/text() | .//h3/text()")
+    if heading:
+        title = " ".join(heading[0].split())
+
+    return LegislationSection(
+        title=title,
+        section_number=section,
+        content=content,
+        content_truncated=truncated,
+        original_length=original_length,
+        in_force=None,
+        extent=["England", "Wales", "Scotland", "Northern Ireland"],
+        version_date=None,
+        prospective=False,
+        source_format="html_fallback",
+        warnings=[
+            warning,
+            "CLML metadata such as exact extent, version date, and in-force status could not be reliably extracted from the HTML fallback.",
+        ],
+    )
+
+
 def _parse_clml_section(xml_text: str, section: str, max_chars: int) -> LegislationSection:
     """Extract a section from CLML XML, truncating content to max_chars."""
     from lxml import etree
@@ -139,6 +199,8 @@ def _parse_clml_section(xml_text: str, section: str, max_chars: int) -> Legislat
         extent=extent or ["England", "Wales", "Scotland", "Northern Ireland"],
         version_date=version_date,
         prospective=prospective,
+        source_format="xml",
+        warnings=[],
     )
 
 
@@ -239,10 +301,17 @@ def register_tools(mcp: FastMCP) -> None:
             params: type, year, number, section identifier, optional max_chars.
         """
         client = ctx.lifespan_context["legislation_http"]
-        url = f"{LEGISLATION_BASE}/{params.type}/{params.year}/{params.number}/section/{params.section}/data.xml"
-        resp = await client.get(url)
-        resp.raise_for_status()
-        return _parse_clml_section(resp.text, params.section, params.max_chars)
+        section = _normalise_section_id(params.section)
+        url = f"{LEGISLATION_BASE}/{params.type}/{params.year}/{params.number}/section/{section}/data.xml"
+        try:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            return _parse_clml_section(resp.text, section, params.max_chars)
+        except LegislationUpstreamError as exc:
+            html_url = f"{LEGISLATION_BASE}/{params.type}/{params.year}/{params.number}/section/{section}"
+            html_resp = await client.get_html(html_url)
+            html_resp.raise_for_status()
+            return _parse_html_section(html_resp.text, section, params.max_chars, str(exc))
 
     @mcp.tool(
         name="get_toc",

--- a/src/modules/legislation/tools.py
+++ b/src/modules/legislation/tools.py
@@ -142,9 +142,9 @@ def _parse_html_section(html_text: str, section: str, max_chars: int, warning: s
         content_truncated=truncated,
         original_length=original_length,
         in_force=None,
-        extent=["England", "Wales", "Scotland", "Northern Ireland"],
+        extent=[],
         version_date=None,
-        prospective=False,
+        prospective=None,
         source_format="html_fallback",
         warnings=[
             warning,

--- a/tests/test_legislation_parsers.py
+++ b/tests/test_legislation_parsers.py
@@ -1,0 +1,361 @@
+"""Tests for legislation section parsers — offline fixtures + live Lex API probe.
+
+Three layers:
+
+1. CLML XML parser (_parse_clml_section)
+   - Runs against a committed fixture, no network.
+   - Verifies the patch adds source_format="xml" and warnings=[].
+
+2. HTML fallback parser (_parse_html_section)
+   - Runs against a committed HTML fixture, no network.
+   - Only exists in the patched codebase — tests will fail until the patch
+     is applied, confirming the patch is needed.
+
+3. Lex API probe (live, network required)
+   - Confirms the API is free/unauthenticated.
+   - Documents the response shape and token cost for section retrieval.
+   - Marked pytest.mark.live so it can be skipped in CI without a token.
+"""
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import tiktoken
+
+FIXTURES = Path(__file__).parent / "live" / "fixtures"
+CLML_FIXTURE = FIXTURES / "housing_act_1988_s21_clml.xml"
+HTML_FIXTURE = FIXTURES / "housing_act_1988_s21_html.html"
+
+LEX_BASE = "https://lex.lab.i.ai.gov.uk"
+
+_enc = tiktoken.get_encoding("cl100k_base")
+
+
+def tok(s: str) -> int:
+    return len(_enc.encode(s))
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+def _clml() -> str:
+    return CLML_FIXTURE.read_text()
+
+
+def _html() -> str:
+    return HTML_FIXTURE.read_text()
+
+
+# ── 1. CLML XML parser ─────────────────────────────────────────────────────
+
+class TestParseClmlSection:
+    """_parse_clml_section — offline, no network."""
+
+    def test_returns_section_content(self):
+        from src.modules.legislation.tools import _parse_clml_section
+        result = _parse_clml_section(_clml(), "21", 10_000)
+        assert "21" in result.section_number
+        assert len(result.content) > 50
+        assert "possession" in result.content.lower()
+
+    def test_extent_parsed_from_metadata(self):
+        from src.modules.legislation.tools import _parse_clml_section
+        result = _parse_clml_section(_clml(), "21", 10_000)
+        # Fixture has ukm:Extent Value="E+W"
+        assert result.extent == ["E", "W"] or set(result.extent) <= {"England", "Wales"}
+
+    def test_version_date_parsed(self):
+        from src.modules.legislation.tools import _parse_clml_section
+        result = _parse_clml_section(_clml(), "21", 10_000)
+        assert result.version_date is not None
+        assert result.version_date.year == 1988
+
+    def test_truncation_respected(self):
+        from src.modules.legislation.tools import _parse_clml_section
+        result = _parse_clml_section(_clml(), "21", 50)
+        assert result.content_truncated is True
+        assert "…[truncated]" in result.content
+        assert len(result.content) <= 70  # 50 chars + suffix
+
+    def test_no_truncation_when_content_fits(self):
+        from src.modules.legislation.tools import _parse_clml_section
+        result = _parse_clml_section(_clml(), "21", 10_000)
+        assert result.content_truncated is False
+        assert "…[truncated]" not in result.content
+
+    # ── patch contract ──────────────────────────────────────────────────────
+    # These assertions verify the two fields added by the patch.
+    # They will FAIL against the current (unpatched) codebase.
+
+    def test_source_format_is_xml(self):
+        """Patch: _parse_clml_section must set source_format='xml'."""
+        from src.modules.legislation.tools import _parse_clml_section
+        result = _parse_clml_section(_clml(), "21", 10_000)
+        assert result.source_format == "xml"
+
+    def test_warnings_is_empty_list(self):
+        """Patch: _parse_clml_section must set warnings=[]."""
+        from src.modules.legislation.tools import _parse_clml_section
+        result = _parse_clml_section(_clml(), "21", 10_000)
+        assert result.warnings == []
+
+    def test_structured_content_token_budget(self):
+        """Typical XML section response stays under 500 tokens."""
+        from src.modules.legislation.tools import _parse_clml_section
+        result = _parse_clml_section(_clml(), "21", 10_000)
+        payload = json.loads(result.model_dump_json())
+        tokens = tok(json.dumps(payload, indent=2))
+        assert tokens < 500, f"XML response is {tokens} tokens — check for bloat"
+
+
+# ── 2. HTML fallback parser ────────────────────────────────────────────────
+
+class TestParseHtmlSection:
+    """_parse_html_section — offline, no network.
+
+    All tests here will fail until the patch is applied.
+    That is intentional — they define the contract for the new function.
+    """
+
+    def _invoke(self, warning="upstream WAF blocked XML", max_chars=10_000):
+        from src.modules.legislation.tools import _parse_html_section  # noqa: PLC0415
+        return _parse_html_section(_html(), "21", max_chars, warning)
+
+    def test_returns_legislation_section(self):
+        from src.modules.legislation.models import LegislationSection
+        result = self._invoke()
+        assert isinstance(result, LegislationSection)
+
+    def test_content_contains_section_text(self):
+        result = self._invoke()
+        assert "possession" in result.content.lower()
+        assert len(result.content) > 50
+
+    def test_source_format_is_html_fallback(self):
+        result = self._invoke()
+        assert result.source_format == "html_fallback"
+
+    def test_warnings_non_empty(self):
+        result = self._invoke(warning="WAF blocked /data.xml")
+        assert len(result.warnings) >= 1
+        assert any("WAF blocked /data.xml" in w or "WAF" in w or "CLML" in w for w in result.warnings)
+
+    def test_in_force_is_none(self):
+        """HTML parser cannot determine in-force status — must be explicit None."""
+        result = self._invoke()
+        assert result.in_force is None
+
+    def test_version_date_is_none(self):
+        """HTML parser cannot determine version date — must be explicit None."""
+        result = self._invoke()
+        assert result.version_date is None
+
+    def test_extent_defaults_to_all_four_nations(self):
+        """HTML parser hard-codes 4-nation extent when metadata is unavailable."""
+        result = self._invoke()
+        assert len(result.extent) == 4
+
+    def test_nav_and_script_stripped_from_content(self):
+        """Navigation links and scripts must not pollute the content field."""
+        result = self._invoke()
+        assert "Previous" not in result.content
+        assert "analytics" not in result.content
+
+    def test_truncation_respected(self):
+        result = self._invoke(max_chars=50)
+        assert result.content_truncated is True
+        assert "…[truncated]" in result.content
+
+    def test_prospective_is_false(self):
+        result = self._invoke()
+        assert result.prospective is False
+
+    def test_structured_content_token_budget(self):
+        """HTML fallback response (with 2 warnings) stays under 600 tokens."""
+        result = self._invoke(
+            warning=(
+                "legislation.gov.uk returned an AWS WAF JavaScript challenge for "
+                "https://www.legislation.gov.uk/ukpga/1988/50/section/21/data.xml. "
+                "XML and HTML fallback are both unavailable. Retry later or use "
+                "legislation_search(fulltext=True)."
+            )
+        )
+        payload = json.loads(result.model_dump_json())
+        tokens = tok(json.dumps(payload, indent=2))
+        assert tokens < 600, f"HTML fallback response is {tokens} tokens"
+
+    def test_token_overhead_vs_xml(self):
+        """HTML fallback should add fewer than 150 tokens vs a comparable XML response.
+
+        The overhead comes from: source_format field, 2 warning strings,
+        and null metadata fields replacing concrete values.
+        """
+        from src.modules.legislation.tools import _parse_clml_section
+
+        xml_result = _parse_clml_section(_clml(), "21", 10_000)
+        html_result = self._invoke(
+            warning=(
+                "legislation.gov.uk returned an AWS WAF JavaScript challenge for "
+                "https://www.legislation.gov.uk/ukpga/1988/50/section/21/data.xml. "
+                "XML and HTML fallback are both unavailable. Retry later or use "
+                "legislation_search(fulltext=True)."
+            )
+        )
+        xml_tokens  = tok(json.dumps(json.loads(xml_result.model_dump_json()),  indent=2))
+        html_tokens = tok(json.dumps(json.loads(html_result.model_dump_json()), indent=2))
+        delta = html_tokens - xml_tokens
+        assert delta < 150, f"HTML fallback adds {delta} tokens vs XML — check warning string length"
+
+
+# ── 3. Section ID normalisation ────────────────────────────────────────────
+
+class TestNormaliseSectionId:
+    """_normalise_section_id — patch adds this helper.
+
+    Tests will fail until the patch is applied.
+    """
+
+    def _norm(self, s: str) -> str:
+        from src.modules.legislation.tools import _normalise_section_id
+        return _normalise_section_id(s)
+
+    def test_plain_number_unchanged(self):
+        assert self._norm("21") == "21"
+
+    def test_strips_section_prefix(self):
+        assert self._norm("section-21") == "21"
+
+    def test_strips_article_prefix(self):
+        assert self._norm("article-3") == "3"
+
+    def test_strips_regulation_prefix(self):
+        assert self._norm("regulation-5") == "5"
+
+    def test_strips_whitespace(self):
+        assert self._norm("  21  ") == "21"
+
+    def test_colon_anchor_stripped(self):
+        # TOC items come back as "section-21:content" — strip the anchor suffix.
+        assert self._norm("section-21:content") == "21"
+
+    def test_alphanumeric_section_unchanged(self):
+        assert self._norm("12A") == "12A"
+
+
+# ── 4. Live Lex API probe ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+@pytest.mark.live
+class TestLexApi:
+    """Probe lex.lab.i.ai.gov.uk — hits network, unauthenticated.
+
+    Run with: pytest tests/test_legislation_parsers.py -m live -v
+    Skip in CI: pytest ... -m "not live"
+    """
+
+    async def test_api_is_unauthenticated(self):
+        """Root and healthcheck must return 200 without any auth header."""
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(f"{LEX_BASE}/healthcheck")
+        assert resp.status_code == 200
+
+    async def test_section_search_returns_s21_housing_act(self):
+        """Semantic section search finds s.21 of Housing Act 1988 without auth."""
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"{LEX_BASE}/legislation/section/search",
+                json={
+                    "query": "notice requiring possession assured shorthold tenancy",
+                    "legislation_id": "ukpga/1988/50",
+                    "size": 5,
+                    "include_text": True,
+                },
+            )
+        assert resp.status_code == 200
+        results = resp.json()
+        assert isinstance(results, list)
+        assert len(results) > 0
+
+        numbers = [r.get("number") for r in results]
+        assert 21 in numbers, f"s.21 not found in top-5 results: {numbers}"
+
+        s21 = next(r for r in results if r.get("number") == 21)
+        assert "possession" in (s21.get("text") or "").lower()
+        assert s21.get("extent") is not None
+
+    async def test_section_search_response_shape(self):
+        """Each section result has the fields we'd need to build LegislationSection."""
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"{LEX_BASE}/legislation/section/search",
+                json={
+                    "query": "notice requiring possession assured shorthold tenancy",
+                    "legislation_id": "ukpga/1988/50",
+                    "size": 1,
+                    "include_text": True,
+                },
+            )
+        result = resp.json()[0]
+        for field in ("text", "title", "number", "extent", "legislation_type",
+                       "legislation_year", "legislation_number"):
+            assert field in result, f"Missing field: {field}"
+
+    async def test_section_text_token_cost(self):
+        """Log token cost of a Lex API section vs the CLML XML path.
+
+        This test always passes — it exists to document the comparison,
+        not to gate on a budget. Check the output to assess the tradeoff.
+        """
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"{LEX_BASE}/legislation/section/search",
+                json={
+                    "query": "notice requiring possession assured shorthold tenancy",
+                    "legislation_id": "ukpga/1988/50",
+                    "size": 1,
+                    "include_text": True,
+                },
+            )
+        lex_result = resp.json()[0]
+        lex_text_tokens = tok(lex_result.get("text", ""))
+        full_payload_tokens = tok(json.dumps(lex_result, indent=2))
+
+        # Compare against our XML fixture
+        from src.modules.legislation.tools import _parse_clml_section
+        xml_result = _parse_clml_section(_clml(), "21", 10_000)
+        xml_payload_tokens = tok(json.dumps(json.loads(xml_result.model_dump_json()), indent=2))
+
+        print(
+            f"\n  Lex API section text only : {lex_text_tokens:>5} tokens"
+            f"\n  Lex API full payload      : {full_payload_tokens:>5} tokens"
+            f"\n  Current XML path payload  : {xml_payload_tokens:>5} tokens"
+            f"\n  Delta (Lex - XML)         : {full_payload_tokens - xml_payload_tokens:>+5} tokens"
+        )
+
+    async def test_lex_lookup_by_type_year_number(self):
+        """Direct lookup endpoint returns Act metadata without a section."""
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{LEX_BASE}/legislation/lookup",
+                json={"legislation_type": "ukpga", "year": 1988, "number": 50},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data.get("title") == "Housing Act 1988"
+        assert isinstance(data.get("extent"), list)
+        assert data.get("number_of_provisions", 0) > 0
+
+    async def test_lex_no_api_key_required_on_all_endpoints(self):
+        """Neither search nor lookup requires an Authorization header."""
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            search_resp = await client.post(
+                f"{LEX_BASE}/legislation/search",
+                json={"query": "Housing Act 1988", "limit": 1},
+            )
+            lookup_resp = await client.post(
+                f"{LEX_BASE}/legislation/lookup",
+                json={"legislation_type": "ukpga", "year": 1988, "number": 50},
+            )
+        assert search_resp.status_code == 200
+        assert lookup_resp.status_code == 200

--- a/tests/test_legislation_parsers.py
+++ b/tests/test_legislation_parsers.py
@@ -151,10 +151,10 @@ class TestParseHtmlSection:
         result = self._invoke()
         assert result.version_date is None
 
-    def test_extent_defaults_to_all_four_nations(self):
-        """HTML parser hard-codes 4-nation extent when metadata is unavailable."""
+    def test_extent_is_empty_when_unknown(self):
+        """HTML parser returns empty extent so callers can decide, not a false default."""
         result = self._invoke()
-        assert len(result.extent) == 4
+        assert result.extent == []
 
     def test_nav_and_script_stripped_from_content(self):
         """Navigation links and scripts must not pollute the content field."""
@@ -167,9 +167,9 @@ class TestParseHtmlSection:
         assert result.content_truncated is True
         assert "…[truncated]" in result.content
 
-    def test_prospective_is_false(self):
+    def test_prospective_is_none_when_unknown(self):
         result = self._invoke()
-        assert result.prospective is False
+        assert result.prospective is None
 
     def test_structured_content_token_budget(self):
         """HTML fallback response (with 2 warnings) stays under 600 tokens."""

--- a/uv.lock
+++ b/uv.lock
@@ -1815,7 +1815,7 @@ wheels = [
 
 [[package]]
 name = "uk-legal-mcp"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },
@@ -1837,6 +1837,7 @@ test = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "tiktoken" },
 ]
 
 [package.metadata]
@@ -1857,6 +1858,7 @@ provides-extras = ["test"]
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "tiktoken", specifier = ">=0.12.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Legislation HTML fallback**: `legislation_get_section` now falls back to scraping the HTML rendering when the CLML XML API returns an error or blocked response. Adds `source_format: "xml" | "html_fallback"` and `warnings: list[str]` to `LegislationSection` so callers know which path was taken.
- **stdio entrypoint**: `main_stdio()` added; `[project.scripts]` now points to it so `uvx uk-legal-mcp` starts in stdio mode for Claude Desktop users instead of launching uvicorn.
- **`_HttpGuard` middleware**: GET /mcp returns a held-open SSE stream (200) so claude.ai's proxy relay doesn't 405-fail the connection. (Backported from fix/claude-ai-get-sse which merged via PR #13 — this branch predates that merge.)

## Test plan

- [ ] Preview Fly app deploys successfully via `preview.yml` CI
- [ ] `legislation_get_section` returns correct content on a section with working CLML XML
- [ ] `legislation_get_section` returns HTML fallback result when XML path is blocked (verify `source_format: "html_fallback"` in response)
- [ ] `uvx uk-legal-mcp` starts in stdio mode (not uvicorn HTTP)
- [ ] Citation tests still pass: `pytest tests/test_citations.py -v`
- [ ] GET /mcp returns 200 text/event-stream (claude.ai compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)