### PR TITLE
feat: log clientInfo and emit connection counter on initialize

### DIFF
--- a/src/gateway.py
+++ b/src/gateway.py
@@ -92,17 +92,19 @@ _log = logging.getLogger("uk_legal_mcp.clients")
 class ClientTrackingMiddleware(Middleware):
     """Log clientInfo and increment connection counter on every initialize."""
 
-    async def on_initialize(self, context: MiddlewareContext, call_next):
-        params = context.message.params
-        info = getattr(params, "clientInfo", None)
-        client_name = getattr(info, "name", "unknown") or "unknown"
-        client_version = getattr(info, "version", "unknown") or "unknown"
-        caps = getattr(params, "capabilities", None)
-        cap_keys = [k for k, v in (caps.model_dump().items() if caps else []) if v is not None]
-        await call_next(context)
-        _log.info("client_connected client=%s version=%s capabilities=%s transport=%s region=%s",
-                  client_name, client_version, cap_keys, TRANSPORT, REGION)
-        client_connections_total.labels(client_name, client_version, TRANSPORT, REGION).inc()
+    async def on_request(self, context: MiddlewareContext, call_next):
+        result = await call_next(context)
+        if context.method == "initialize":
+            params = context.message.params
+            info = getattr(params, "clientInfo", None)
+            client_name = getattr(info, "name", "unknown") or "unknown"
+            client_version = getattr(info, "version", "unknown") or "unknown"
+            caps = getattr(params, "capabilities", None)
+            cap_keys = [k for k, v in (caps.model_dump().items() if caps else []) if v is not None]
+            _log.info("client_connected client=%s version=%s capabilities=%s transport=%s region=%s",
+                      client_name, client_version, cap_keys, TRANSPORT, REGION)
+            client_connections_total.labels(client_name, client_version, TRANSPORT, REGION).inc()
+        return result
 
 
 class PrometheusMiddleware(Middleware):

--- a/src/gateway.py
+++ b/src/gateway.py
@@ -80,6 +80,28 @@ tool_duration_seconds = Histogram(
     labelnames=["tool", "transport", "region"],
     buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
 )
+client_connections_total = PromCounter(
+    "uk_legal_client_connections_total",
+    "Count of MCP client initialize handshakes.",
+    labelnames=["client_name", "client_version", "transport", "region"],
+)
+
+_log = logging.getLogger("uk_legal_mcp.clients")
+
+
+class ClientTrackingMiddleware(Middleware):
+    """Log clientInfo and increment connection counter on every initialize."""
+
+    async def on_initialize(self, context: MiddlewareContext, call_next):
+        params = context.message.params or {}
+        info = params.get("clientInfo") or {}
+        client_name = info.get("name", "unknown")
+        client_version = info.get("version", "unknown")
+        capabilities = params.get("capabilities") or {}
+        await call_next(context)
+        _log.info("client_connected client=%s version=%s capabilities=%s transport=%s region=%s",
+                  client_name, client_version, list(capabilities.keys()), TRANSPORT, REGION)
+        client_connections_total.labels(client_name, client_version, TRANSPORT, REGION).inc()
 
 
 class PrometheusMiddleware(Middleware):
@@ -145,6 +167,9 @@ gateway.add_middleware(StructuredLoggingMiddleware(
     include_payload_length=True,
     estimate_payload_tokens=True,
 ))
+
+# Client tracking — logs clientInfo + increments client_connections_total on initialize
+gateway.add_middleware(ClientTrackingMiddleware())
 
 # Prometheus metrics — fleet-standard tool_calls_total + tool_duration_seconds
 gateway.add_middleware(PrometheusMiddleware())

--- a/src/gateway.py
+++ b/src/gateway.py
@@ -93,14 +93,15 @@ class ClientTrackingMiddleware(Middleware):
     """Log clientInfo and increment connection counter on every initialize."""
 
     async def on_initialize(self, context: MiddlewareContext, call_next):
-        params = context.message.params or {}
-        info = params.get("clientInfo") or {}
-        client_name = info.get("name", "unknown")
-        client_version = info.get("version", "unknown")
-        capabilities = params.get("capabilities") or {}
+        params = context.message.params
+        info = getattr(params, "clientInfo", None)
+        client_name = getattr(info, "name", "unknown") or "unknown"
+        client_version = getattr(info, "version", "unknown") or "unknown"
+        caps = getattr(params, "capabilities", None)
+        cap_keys = [k for k, v in (caps.model_dump().items() if caps else []) if v is not None]
         await call_next(context)
         _log.info("client_connected client=%s version=%s capabilities=%s transport=%s region=%s",
-                  client_name, client_version, list(capabilities.keys()), TRANSPORT, REGION)
+                  client_name, client_version, cap_keys, TRANSPORT, REGION)
         client_connections_total.labels(client_name, client_version, TRANSPORT, REGION).inc()
 
 

--- a/src/gateway.py
+++ b/src/gateway.py
@@ -86,7 +86,7 @@ client_connections_total = PromCounter(
     labelnames=["client_name", "client_version", "transport", "region"],
 )
 
-_log = logging.getLogger("uk_legal_mcp.clients")
+_log = logging.getLogger("fastmcp.uk_legal_mcp.clients")
 
 
 class ClientTrackingMiddleware(Middleware):

--- a/uv.lock
+++ b/uv.lock
@@ -1815,7 +1815,7 @@ wheels = [
 
 [[package]]
 name = "uk-legal-mcp"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },


### PR DESCRIPTION
## Summary

- Adds `ClientTrackingMiddleware` using FastMCP's `on_initialize` hook
- Logs `client_name`, `client_version`, and declared capabilities on every MCP handshake — picked up by `StructuredLoggingMiddleware` as structured JSON
- Increments new `uk_legal_client_connections_total` Prometheus counter (labels: `client_name`, `client_version`, `transport`, `region`)
- No changes to tools, resources, or existing metrics

## Test plan

- [ ] Preview app deploys successfully
- [ ] Connect from claude.ai — verify `client_connected` log line appears in `fly logs`
- [ ] Connect from Claude Code — verify different `client_name` logged
- [ ] `GET /metrics` shows `uk_legal_client_connections_total` counter with correct labels
- [ ] Existing tool calls and Prometheus metrics unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)