### PR TITLE
fix: point bouch.dev links at the restored server pages

### DIFF
--- a/server.json
+++ b/server.json
@@ -4,7 +4,7 @@
   "title": "UK Legal Research",
   "description": "UK legal research — case law, legislation, Hansard, bills, votes, committees, HMRC, citations",
   "version": "0.6.0",
-  "websiteUrl": "https://bouch.dev/products/legal-research",
+  "websiteUrl": "https://bouch.dev/products/uk-legal-mcp",
   "repository": {
     "url": "https://github.com/paulieb89/uk-legal-mcp",
     "source": "github"


### PR DESCRIPTION
`websiteUrl` pointed at `/products/legal-research`, a skill page from the pre-relaunch bouch.dev that 404s (it currently 308s to the server page). Now points directly at **https://bouch.dev/products/uk-legal-mcp**.

This field is propagated by the MCP registry to Glama, PulseMCP and other aggregators, so it decides where registry traffic lands. The destination carries the endpoint URL and connect instructions for claude.ai, Claude Desktop, Claude Code, ChatGPT and Cursor.

Note: `server.json` has an uncommitted 0.6.0 → 0.6.1 version bump in the local working tree that is not in this PR — this branch is cut from `origin/main`, so that bump is untouched and will need rebasing on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)