### PR TITLE
fix(registry): point websiteUrl at the current server page

### DIFF
--- a/server.json
+++ b/server.json
@@ -4,7 +4,7 @@
   "title": "UK Legal Research",
   "description": "UK legal research — case law, legislation, Hansard, bills, votes, committees, HMRC, citations",
   "version": "0.6.0",
-  "websiteUrl": "https://bouch.dev/products/legal-research",
+  "websiteUrl": "https://bouch.dev/products/uk-legal-mcp",
   "repository": {
     "url": "https://github.com/paulieb89/uk-legal-mcp",
     "source": "github"


### PR DESCRIPTION
`websiteUrl` pointed at `/products/legal-research`, a skill page from the pre-relaunch bouch.dev. It now points directly at `https://bouch.dev/products/uk-legal-mcp`.

This field is propagated by the MCP registry to Glama, PulseMCP and other aggregators, so it decides where registry traffic lands. The destination carries the endpoint URL and connect instructions for claude.ai, Claude Desktop, Claude Code, ChatGPT and Cursor.

## Verified at the boundary

| URL | Result |
|---|---|
| `/products/legal-research` | **308** → `/products/uk-legal-mcp` → 200 |
| `/products/uk-legal-mcp` | **200** direct |

So the old URL does currently resolve, via redirect — this isn't a live 404. It's still worth pointing directly: aggregators don't reliably follow redirects when scraping metadata, and the redirect is a courtesy that can be withdrawn whenever the site is next reorganised.

## On the version bump — deliberately excluded

The local working tree carries an uncommitted `0.6.0 → 0.6.1` bump to both `version` and `packages[].version`. I've left it out, because **PyPI's latest published release of `uk-legal-mcp` is 0.6.0** — 0.6.1 does not exist. Declaring it in `packages[].version` would advertise a package version that can't be installed, breaking `uvx uk-legal-mcp` for anyone coming through the registry entry.

Worth knowing: `main` is already inconsistent on this — `pyproject.toml` says `0.6.1` while `server.json` says `0.6.0`. That predates this PR. The safe order to resolve it is:

1. Publish 0.6.1 to PyPI
2. Bump `server.json` (both version fields)
3. Republish to the registry

If the registry requires a version increment to accept an updated `server.json`, this websiteUrl change won't propagate until that sequence completes — the change is still correct to land now, it just may not reach aggregators until the next release.

Supersedes #47 (closed), which made the same one-line change from a branch cut before the error-classification work landed.

https://claude.ai/code/session_01Sef4KurCzB49PiMRPsVSsB
