### PR TITLE
chore: align serverInfo websiteUrl and correct stale .well-known paths

### DIFF
--- a/.claude/rules/gateway.md
+++ b/.claude/rules/gateway.md
@@ -23,7 +23,7 @@ Tools registered via `register_tools(mcp)` inside the module's `tools.py`.
 Do not register tools directly on the gateway — they won't be namespaced correctly.
 
 ## Custom routes (not MCP tools)
-`/health`, `/metrics`, `/.well-known/mcp.json`, `/.well-known/agent.json` are
+`/health`, `/metrics`, `/.well-known/mcp/server-card.json`, `/.well-known/glama.json` are
 Starlette routes added to the gateway directly. They are tested in `tests/test_gateway.py`.
 Any new custom routes must be added to that test file.
 

--- a/src/gateway.py
+++ b/src/gateway.py
@@ -143,7 +143,7 @@ class PrometheusMiddleware(Middleware):
 gateway = FastMCP(
     name="uk-legal-mcp",
     version=_PROJECT_VERSION,
-    website_url="https://github.com/paulieb89/uk-legal-mcp",
+    website_url="https://bouch.dev/products/uk-legal-mcp",
     mask_error_details=True,
     lifespan=http_lifespan,
     instructions=(


### PR DESCRIPTION
Two inconsistencies found while inventorying every surface ahead of the 0.6.1 release. Both are one-line changes.

## 1. Three websiteUrls, two of them disagreeing

| Surface | Was | Now |
|---|---|---|
| `serverInfo.websiteUrl` (`gateway.py:146`) | `github.com/paulieb89/uk-legal-mcp` | `bouch.dev/products/uk-legal-mcp` |
| `server.json` `websiteUrl` | `bouch.dev/products/legal-research` | fixed in #50 |

A client connecting to the server and a user arriving from a registry listing were being sent to different places. Both now point at the product page, which carries the endpoint URL and connect instructions for claude.ai, Claude Desktop, Claude Code, ChatGPT and Cursor. **Judgement call** — if you'd rather `serverInfo` point at the repo for developers, it's one line to revert.

## 2. The rules file documented two endpoints that don't exist

`.claude/rules/gateway.md:26` listed `/.well-known/mcp.json` and `/.well-known/agent.json`. Verified against the live server:

```
/.well-known/mcp/server-card.json   200
/.well-known/glama.json             200
/.well-known/mcp.json               404
/.well-known/agent.json             404
```

The rule now names the two routes `gateway.py` actually serves and `tests/test_gateway.py` actually tests.

## What we learned about those routes

None of this was written down anywhere, so it's in the commit message too:

- **`/.well-known/glama.json` is real.** Glama documents exactly this shape for domain-ownership claiming, separate from the registry entry. Our implementation matches their schema verbatim. Keep it.
- **`/.well-known/mcp/server-card.json` is not in the spec.** It traces to SEP-1649 (`modelcontextprotocol` PR #2127), still a **draft**. Worth keeping, worth knowing it rests on a proposal. The handler is named `smithery_server_card`, but I could not confirm Smithery actually requires this path — treat that justification as unverified.
- **The only spec'd `.well-known` paths are the OAuth ones** (RFC 9728 protected-resource, RFC 8414 authorization-server), and only when auth is configured. This server has no auth provider (grepped: no `auth=`, `OAuthProvider`, `TokenVerifier`), so they don't apply. FastMCP generates those automatically when an auth provider is attached, and never generates any other `.well-known` route — so every one we serve is a hand-written `custom_route`, as it should be.

## Verification

90 tests pass (gateway, error classification, citations) — including the gateway tests that assert on the `.well-known` routes.

**Worth knowing before we add CI**: the other 21 tests need `tests/live/fixtures/`, which `tests/live/.gitignore` excludes. There are 23 fixture files present locally and none in git, so those tests cannot run on a fresh clone. A pytest workflow will need to deselect them or the fixtures need committing.

https://claude.ai/code/session_01Sef4KurCzB49PiMRPsVSsB
