### PR TITLE
chore(deps): regenerate uv.lock to match pyproject.toml

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -533,13 +533,12 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.4"
+version = "3.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
-    { name = "griffelib" },
     { name = "httpx" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -559,18 +558,9 @@ dependencies = [
     { name = "watchfiles" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/42/7eed0a38e3b7a386805fecacf8a5a9353a2b3040395ef9e30e585d8549ac/fastmcp-3.2.3.tar.gz", hash = "sha256:4f02ae8b00227285a0cf6544dea1db29b022c8cdd8d3dfdec7118540210ae60a", size = 26328743, upload-time = "2026-04-09T22:05:03.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
-]
-
-[[package]]
-name = "griffelib"
-version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/48/84b6dcba793178a44b9d99b4def6cd62f870dcfc5bb7b9153ac390135812/fastmcp-3.2.3-py3-none-any.whl", hash = "sha256:cc50af6eed1f62ed8b6ebf4987286d8d1d006f08d5bec739d5c7fb76160e0911", size = 707260, upload-time = "2026-04-09T22:05:01.225Z" },
 ]
 
 [[package]]
@@ -1892,7 +1882,7 @@ wheels = [
 
 [[package]]
 name = "uk-legal-mcp"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "curl-cffi" },
@@ -1921,7 +1911,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "curl-cffi", specifier = ">=0.15.0" },
-    { name = "fastmcp", specifier = "==3.2.4" },
+    { name = "fastmcp", specifier = "==3.2.3" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "lxml", specifier = "==6.0.4" },
     { name = "mcp", specifier = "==1.27.0" },


### PR DESCRIPTION
The committed lockfile disagreed with committed `pyproject.toml` and **failed `uv lock --check`**.

| | `pyproject.toml` | `uv.lock` (committed) | `uv.lock` (this PR) |
|---|---|---|---|
| `uk-legal-mcp` version | `0.6.1` | `0.6.0` ❌ | `0.6.1` ✅ |
| fastmcp pin | `==3.2.3` | `==3.2.4` ❌ | `==3.2.3` ✅ |

```
before:  The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
after:   Resolved 95 packages in 0.51ms
```

## What this is not

**Not a dependency change.** `pyproject.toml` has pinned `fastmcp==3.2.3` since `bea6024` (29 Jun) and is untouched here. The lockfile had simply never been regenerated after that revert, so it still carried 3.2.4 plus the `griffelib` transitive dependency 3.2.4 pulls in.

Regenerated with `uv lock` (uv 0.9.5), not hand-edited — and byte-identical to the lockfile already sitting in the local working tree, so this is the change that was pending there.

## Why it matters before deploying

A build using `uv sync --locked` against the committed lockfile **fails outright**. Any build resolving from it installs fastmcp **3.2.4** — the version deliberately reverted away from in `bea6024` because it wraps single-Pydantic-model tool params in a `params` field, breaking clients that send flat args.

## Parked, not addressed here

`fastmcp==3.2.3` makes this **the only server in the fleet pinned below 3.2.4**, which was taken as a security patch (CVE-2026-32871 SSRF/path traversal, CVE-2026-27124 OAuth confused deputy, CVE-2025-64340 command injection — as recorded in `0618fae`; I have not independently verified those IDs).

No tool in this server currently appears to take a single Pydantic model as a parameter — the `BaseModel` classes under `src/modules/*/models.py` are all response models — so the regression that justified the revert may no longer apply. That needs an actual schema comparison against 3.2.4 before the pin moves, which is why it isn't in this PR.

https://claude.ai/code/session_01Sef4KurCzB49PiMRPsVSsB
