### PR TITLE
chore(release): prepare 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 All notable changes to `uk-legal-mcp` are documented here. Format loosely follows [Keep a Changelog](https://keepachangelog.com/). Version numbers follow semver.
 
-## [0.6.1] — 2026-06-29
+## [0.6.1] — 2026-09-04
+
+Prepared 2026-06-29 but never released — no tag was cut, so PyPI and the MCP
+registry never received it and the 29 June production deploy went out by hand
+as 0.6.0. This release ships the June work together with everything that
+landed since.
 
 ### Fixed
+
+- **curl_cffi HTTP failures were classified as `unknown` / non-retryable** — `raise_http_tool_error` type-checked only `httpx` exceptions, but the legislation client is curl_cffi (Chrome impersonation, required to pass CloudFront). `curl_cffi.requests.exceptions.HTTPError` shares no ancestor with `httpx.HTTPStatusError`, so every legislation HTTP error fell through to the generic catch-all with `is_retryable=False` and the status code was never read — making the existing 429/503 → transient mapping unreachable for all three `legislation_*` tools. Observed live: three consecutive calls returned `{"error_category": "unknown", "is_retryable": false}` for an upstream 438 that cleared itself within a minute. Status classification is now shared by both client families, and unrecognised 4xx/5xx are treated as transient and retryable rather than terminal.
 
 - **FastMCP pinned back to 3.2.3** — 3.2.4 introduced a breaking change that wraps single-Pydantic-model tool parameters in a `params` envelope, causing all 8 modules to fail with `Missing required argument` / `Unexpected keyword argument` errors on every tool call. 3.2.3 generates flat schemas as expected by MCP clients.
 - **LEGISLATION regex: lowercase connector words** — Act titles containing lowercase connectors (e.g. "Landlord and Tenant Act 1985", "Town and Country Planning Act 1990") were not matched because the pattern required every word to start with a capital letter. Fixed to allow lowercase inner words.
@@ -13,7 +20,16 @@ All notable changes to `uk-legal-mcp` are documented here. Format loosely follow
 
 ### Tests
 
+- 15 tests added for error classification (`tests/test_error_classification.py`), asserting both client families classify identically and that `unknown` is unreachable when a status code exists.
 - 9 regression tests added covering both citation bugs: 4 for legislation lowercase connectors, 5 for EWHC trailing division qualifiers (including bare-EWHC still-ambiguous case). Suite: 51 tests, all passing.
+
+### Changed
+
+- **`websiteUrl` now points at the current product page** — `server.json` pointed at `/products/legal-research`, a pre-relaunch skill page that 308s to `/products/uk-legal-mcp`. The registry propagates this field to Glama, PulseMCP and other aggregators, and the registry entry has carried the stale URL since 0.4.0.
+- **`serverInfo.websiteUrl` aligned with `server.json`** — it pointed at the GitHub repo, so a connecting client and a user arriving from a registry listing were sent to different places.
+- **`.claude/rules/gateway.md` corrected** — it documented `/.well-known/mcp.json` and `/.well-known/agent.json`; neither exists. The real routes are `/.well-known/mcp/server-card.json` and `/.well-known/glama.json`.
+- **`uv.lock` regenerated** — it disagreed with `pyproject.toml` on both the package version and the fastmcp pin, and failed `uv lock --check`. A `uv sync --locked` build would have failed outright.
+- **Removed the Fly.io per-PR preview workflow** — it had failed on every PR since May (`unauthorized` at app-creation time, a deploy-scoped token cannot create apps).
 
 ## [0.6.0] — 2026-06-15
 

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.paulieb89/uk-legal-mcp",
   "title": "UK Legal Research",
   "description": "UK legal research — case law, legislation, Hansard, bills, votes, committees, HMRC, citations",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "websiteUrl": "https://bouch.dev/products/uk-legal-mcp",
   "repository": {
     "url": "https://github.com/paulieb89/uk-legal-mcp",
@@ -16,7 +16,7 @@
     {
       "registryType": "pypi",
       "identifier": "uk-legal-mcp",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "runtimeHint": "uvx",
       "transport": { "type": "stdio" }
     }


### PR DESCRIPTION
Bumps `server.json` to 0.6.1 (both `version` and `packages[].version`) and refreshes the CHANGELOG entry. Last step before cutting the tag.

## Why 0.6.1 and not 0.6.2

0.6.1 was prepared on 29 June and **never released** — no tag was cut, so `release.yml` never fired, PyPI never received it, and the 29 June production deploy went out by hand still reporting 0.6.0.

Nothing anywhere claims 0.6.1:

| Surface | Highest version |
|---|---|
| PyPI | `0.6.0` |
| Git tags / GH releases | `v0.6.0` |
| MCP registry | **`0.4.0`** |

The registry's immutability rule only bites on versions actually published, so 0.6.1 is free. Skipping to 0.6.2 would leave a CHANGELOG entry for a version that never existed and a gap to explain later.

## Note on the registry

It's stranded at **0.4.0** — only 0.3.0 and 0.4.0 were ever published, with 0.4.0 still flagged `isLatest`. PyPI moved through 0.4.1 → 0.6.0 without the registry hearing about any of it, and both registry entries still carry the old `websiteUrl`. Publishing 0.6.1 will jump it 0.4.0 → 0.6.1 and finally correct the URL that Glama and PulseMCP have been showing for five releases.

## Version coherence in the tree to be tagged

```
pyproject.toml  0.6.1
server.json     0.6.1
uv.lock         0.6.1
CHANGELOG       [0.6.1] — 2026-09-04
uv lock --check  Resolved 95 packages ✓
```

`server.json` is safe to commit at 0.6.1 now — immutability governs *publishing*, not repository state, and publishing happens after PyPI has the release.

## CHANGELOG

Redated to today and extended to cover what landed after June: the curl_cffi error-classification fix, the `websiteUrl` corrections in both `server.json` and `serverInfo`, the corrected `.well-known` paths, the `uv.lock` regeneration, and the removal of the broken Fly preview workflow. The original June entries (fastmcp pin, two OSCOLA regex fixes, `.dockerignore` globs) are preserved as written.

## Verification

**188 passed** in a checkout that has `tests/live/fixtures/`. In a fresh checkout 21 tests fail purely because that directory is gitignored and absent — unrelated to this change, and the reason CI is parked for now.

## Next

1. Merge this
2. Cut release **`v0.6.1`** → `release.yml` publishes to PyPI (trusted publishing) then deploys to Fly
3. `mcp-publisher` to push 0.6.1 to the MCP registry — after PyPI, so `packages[].version` resolves

https://claude.ai/code/session_01Sef4KurCzB49PiMRPsVSsB
