### PR TITLE
chore: gitignore mcp-publisher credential files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ writing-mcp-tools-review.html
 eval-review-top.png
 *-workspace/
 .playwright-mcp/
+
+# mcp-publisher credentials — written to the repo root by `mcp-publisher login`
+.mcpregistry_*


### PR DESCRIPTION
`mcp-publisher login github` writes two credential files to the repo root:

```
.mcpregistry_github_token
.mcpregistry_registry_token
```

**Neither was gitignored.** They sat untracked in the working tree of a public repo — one `git add .` away from being committed and pushed.

## Severity: near miss, not an exposure

- **Never committed** — `git log --all -- '.mcpregistry_*'` is empty, so no history rewrite and no token rotation strictly required
- File modes are `0600` (owner-only)
- I applied a local `.git/info/exclude` entry immediately so they're protected on this machine right now; this PR makes it permanent and shared

## Scope

Checked every repo in the fleet — **only `uk-legal-mcp` has these files**. They were created during the 0.6.1 registry publish, which is also how they surfaced.

## Worth considering separately

Rotating the registry token anyway is cheap insurance, and the GitHub token that `mcp-publisher login` mints is the more sensitive of the two. Your call — there's no evidence either leaked.

https://claude.ai/code/session_01Sef4KurCzB49PiMRPsVSsB
